### PR TITLE
Fixes returned ping object missing required keys

### DIFF
--- a/modules/stub/src/stub.js
+++ b/modules/stub/src/stub.js
@@ -80,6 +80,8 @@
           gdprApplies: gdprApplies,
           cmpLoaded: false,
           cmpStatus: 'stub',
+          apiVersion: '2.0',
+          displayStatus: 'hidden'
         };
 
         if (typeof args[2] === 'function') {


### PR DESCRIPTION
According to specs, the returned PingReturn object coming from the stub should include the `apiVersion` and `displayStatus` keys.