### PR TITLE
Add CLI support for TCv1 strings

### DIFF
--- a/modules/cli/src/index.ts
+++ b/modules/cli/src/index.ts
@@ -9,7 +9,7 @@ let encoded = '';
 
 for (const arg of args) {
 
-  if (arg.charAt(0) === 'C') {
+  if (arg.charAt(0) === 'C' || arg.charAt(0) === 'B') {
 
     encoded = arg;
     break;

--- a/modules/cmpapi/test/ReportedIssues.test.ts
+++ b/modules/cmpapi/test/ReportedIssues.test.ts
@@ -179,7 +179,6 @@ describe('Reported github issues', (): void => {
     window[API_FUNCTION_NAME](TCFCommands.GET_TC_DATA, null, callback);
     window[API_FUNCTION_NAME](TCFCommands.GET_TC_DATA, null, callback, [9]);
 
-    debugger;
     const cmpApi = new CmpApi(makeRandomInt(2, Math.pow(2, 6)), makeRandomInt(2, Math.pow(2, 6)));
     cmpApi.update(TCStringFactory.base());
 


### PR DESCRIPTION
Simple change to support TCv1 strings.

I wanted to use the CLI to debug some TC strings we are getting and was a bit confused that the CLI only supports TCv2 strings. You can imagine that in the migration phase from v1 to v2 there is a wild mix between v1, v2 and plain wrong TC strings coming in.

If the exclusion is by design, just close this.