### PR TITLE
Base64Url - Do not add extra padding on strings that are already of length LCM

### DIFF
--- a/modules/core/src/encoder/Base64Url.ts
+++ b/modules/core/src/encoder/Base64Url.ts
@@ -49,7 +49,8 @@ export class Base64Url {
      * Pad the end of the string to the least common mutliple of 6 (basis for
      * base64) and 8 (one byte)
      */
-    str += '0'.repeat(this.LCM - (str.length % this.LCM));
+    const padding = str.length % this.LCM;
+    str += padding ? '0'.repeat(this.LCM - padding) : '';
 
     let result = '';
 

--- a/modules/core/test/encoder/Base64Url.test.ts
+++ b/modules/core/test/encoder/Base64Url.test.ts
@@ -64,6 +64,9 @@ export function run(): void {
     // length: 16
     shouldBeGood(createRandomBinaryString(Math.pow(2, 4)));
 
+    // length: 24
+    shouldBeGood(createRandomBinaryString(24));
+
     // length: 64
     shouldBeGood(createRandomBinaryString(Math.pow(2, 6)));
 


### PR DESCRIPTION
While attempting to implement the TCF framework into the [Osano](https://www.osano.com) consent manager, I came across an issue while attempting to validate TCStrings that were already of a bit length that was a factor of 24 (the LCM of 6 and 8 being used in the `encode` method).

This PR does the following:
- Verify that bit string is not already of LCM length before padding
- Add test for bit string of LCM length