### PR TITLE
formatting and minor code adjustments

### DIFF
--- a/modules/core/src/encoder/Base64Url.ts
+++ b/modules/core/src/encoder/Base64Url.ts
@@ -7,19 +7,24 @@ export class Base64Url {
    * in that '+' and '/' are replaced with '-' and '_'.
    */
   private static DICT = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-  private static REVERSE_DICT: Map<string, number> = new Map([
-    ['A', 0], ['B', 1], ['C', 2], ['D', 3], ['E', 4], ['F', 5],
-    ['G', 6], ['H', 7], ['I', 8], ['J', 9], ['K', 10], ['L', 11],
-    ['M', 12], ['N', 13], ['O', 14], ['P', 15], ['Q', 16], ['R', 17],
-    ['S', 18], ['T', 19], ['U', 20], ['V', 21], ['W', 22], ['X', 23],
-    ['Y', 24], ['Z', 25], ['a', 26], ['b', 27], ['c', 28], ['d', 29],
-    ['e', 30], ['f', 31], ['g', 32], ['h', 33], ['i', 34], ['j', 35],
-    ['k', 36], ['l', 37], ['m', 38], ['n', 39], ['o', 40], ['p', 41],
-    ['q', 42], ['r', 43], ['s', 44], ['t', 45], ['u', 46], ['v', 47],
-    ['w', 48], ['x', 49], ['y', 50], ['z', 51], ['0', 52], ['1', 53],
-    ['2', 54], ['3', 55], ['4', 56], ['5', 57], ['6', 58], ['7', 59],
-    ['8', 60], ['9', 61], ['-', 62], ['_', 63],
-  ]);
+  private static REVERSE_DICT: Record<string, number> = {
+    'A': 0, 'B': 1, 'C': 2, 'D': 3, 'E': 4,
+    'F': 5, 'G': 6, 'H': 7, 'I': 8, 'J': 9,
+    'K': 10, 'L': 11, 'M': 12, 'N': 13,
+    'O': 14, 'P': 15, 'Q': 16, 'R': 17,
+    'S': 18, 'T': 19, 'U': 20, 'V': 21,
+    'W': 22, 'X': 23, 'Y': 24, 'Z': 25,
+    'a': 26, 'b': 27, 'c': 28, 'd': 29,
+    'e': 30, 'f': 31, 'g': 32, 'h': 33,
+    'i': 34, 'j': 35, 'k': 36, 'l': 37,
+    'm': 38, 'n': 39, 'o': 40, 'p': 41,
+    'q': 42, 'r': 43, 's': 44, 't': 45,
+    'u': 46, 'v': 47, 'w': 48, 'x': 49,
+    'y': 50, 'z': 51, '0': 52, '1': 53,
+    '2': 54, '3': 55, '4': 56, '5': 57,
+    '6': 58, '7': 59, '8': 60, '9': 61,
+    '-': 62, '_': 63
+  };
 
   /**
    * log2(64) = 6
@@ -89,7 +94,7 @@ export class Base64Url {
       /**
        * index the binary value of the character from out reverse map
        */
-      const strBits = this.REVERSE_DICT.get(str[i]).toString(2);
+      const strBits = this.REVERSE_DICT[str[i]].toString(2);
 
       /**
        * Since a bit string converted to an integer on encoding will lose

--- a/modules/core/src/encoder/BitLength.ts
+++ b/modules/core/src/encoder/BitLength.ts
@@ -1,4 +1,5 @@
 import {Fields} from '../model';
+
 export class BitLength {
 
   public static readonly [Fields.cmpId]: number = 12;

--- a/modules/core/src/encoder/field/DateEncoder.ts
+++ b/modules/core/src/encoder/field/DateEncoder.ts
@@ -21,11 +21,7 @@ export class DateEncoder {
 
     }
 
-    const date: Date = new Date();
-
-    date.setTime(IntEncoder.decode(value, numBits) * 100);
-
-    return date;
+    return new Date(IntEncoder.decode(value, numBits) * 100);
 
   }
 

--- a/modules/core/src/encoder/field/FixedVectorEncoder.ts
+++ b/modules/core/src/encoder/field/FixedVectorEncoder.ts
@@ -28,11 +28,11 @@ export class FixedVectorEncoder {
 
     const vector: Vector = new Vector();
 
-    for (let i = 1; i <= numBits; i ++) {
+    for (let i = 0; i < numBits; i++) {
 
-      if (BooleanEncoder.decode(value[i - 1])) {
+      if (BooleanEncoder.decode(value[i])) {
 
-        vector.set(i);
+        vector.set(i + 1);
 
       }
 

--- a/modules/core/src/encoder/field/LangEncoder.ts
+++ b/modules/core/src/encoder/field/LangEncoder.ts
@@ -9,14 +9,20 @@ import {
 
 export class LangEncoder {
 
+  private static ASCII_START: number = 65;
+
   public static encode(value: string, numBits: number): string {
+
+    if (numBits % 2 !== 0) {
+
+      throw new EncodingError(`numBits must be even, ${numBits} is not valid`);
+
+    }
 
     value = value.toUpperCase();
 
-    const ASCII_START = 65;
-    const firstLetter: number = value.charCodeAt(0) - ASCII_START;
-
-    const secondLetter: number = value.charCodeAt(1) - ASCII_START;
+    const firstLetter: number = value.charCodeAt(0) - LangEncoder.ASCII_START;
+    const secondLetter: number = value.charCodeAt(1) - LangEncoder.ASCII_START;
 
     // check some things to throw some good errors
     if (firstLetter < 0 || firstLetter > 25 || secondLetter < 0 || secondLetter > 25) {
@@ -25,13 +31,8 @@ export class LangEncoder {
 
     }
 
-    if (numBits % 2 === 1) {
-
-      throw new EncodingError(`numBits must be even, ${numBits} is not valid`);
-
-    }
-
     numBits = numBits/2;
+
     const firstLetterBString: string = IntEncoder.encode(firstLetter, numBits);
     const secondLetterBString: string = IntEncoder.encode(secondLetter, numBits);
 
@@ -41,25 +42,18 @@ export class LangEncoder {
 
   public static decode(value: string, numBits: number): string {
 
-    let retr: string;
-
     // is it an even number of bits? we have to divide it
-    if (numBits === value.length && !(value.length % 2)) {
-
-      const ASCII_START = 65;
-      const mid: number = value.length/2;
-      const firstLetter = IntEncoder.decode(value.slice(0, mid), mid) + ASCII_START;
-      const secondLetter = IntEncoder.decode(value.slice(mid), mid) + ASCII_START;
-
-      retr = String.fromCharCode(firstLetter) + String.fromCharCode(secondLetter);
-
-    } else {
+    if (numBits !== value.length || value.length % 2 !== 0) {
 
       throw new DecodingError('invalid bit length for language');
 
     }
 
-    return retr;
+    const mid: number = value.length/2;
+    const firstLetter = IntEncoder.decode(value.slice(0, mid), mid) + LangEncoder.ASCII_START;
+    const secondLetter = IntEncoder.decode(value.slice(mid), mid) + LangEncoder.ASCII_START;
+
+    return String.fromCharCode(firstLetter) + String.fromCharCode(secondLetter);
 
   }
 

--- a/modules/core/src/encoder/field/VendorVectorEncoder.ts
+++ b/modules/core/src/encoder/field/VendorVectorEncoder.ts
@@ -121,10 +121,9 @@ export class VendorVectorEncoder {
      */
     if (encodingType === VectorEncodingType.RANGE) {
 
-      vector = new Vector();
-
       const numEntries: number = IntEncoder.decode(value.substr(index, BitLength.numEntries), BitLength.numEntries);
 
+      vector = new Vector();
       index += BitLength.numEntries;
 
       // loop through each group of entries
@@ -187,7 +186,7 @@ export class VendorVectorEncoder {
     let rangeString = IntEncoder.encode(numEntries, BitLength.numEntries);
 
     // each range
-    ranges.forEach((range: number[]): void => {
+    for (const range of ranges) {
 
       // is this range a single?
       const single = (range.length === 1);
@@ -206,7 +205,7 @@ export class VendorVectorEncoder {
 
       }
 
-    });
+    }
 
     return rangeString;
 

--- a/modules/core/src/encoder/sequence/FieldSequence.ts
+++ b/modules/core/src/encoder/sequence/FieldSequence.ts
@@ -17,6 +17,7 @@ export class FieldSequence implements SequenceVersionMap {
       Fields.vendorConsents,
     ],
   };
+
   public readonly '2': SVMItem = {
     [Segment.CORE]: [
       Fields.version,

--- a/modules/core/src/model/Vector.ts
+++ b/modules/core/src/model/Vector.ts
@@ -88,11 +88,12 @@ class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
          * all the ids and find the biggest one.
          */
         this.maxId_ = 0;
-        this.set_.forEach((id: number): void => {
 
-          this.maxId_ = Math.max(this.maxId, id);
+        for (const id of this.set_) {
 
-        });
+          this.maxId_ = Math.max(this.maxId_, id);
+
+        }
 
       }
 
@@ -102,39 +103,51 @@ class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
 
   private isIntMap<T>(item: unknown): item is IntMap<T> {
 
-    let result = (typeof item === 'object');
-    result = (result && Object.keys(item).every((key: string): boolean => {
+    if (typeof item === 'object') {
 
-      let itemResult =Number.isInteger(parseInt(key, 10));
+      for (const key of Object.keys(item)) {
 
-      itemResult = (itemResult && this.isValidNumber(item[key].id));
-      itemResult = (itemResult && item[key].name !== undefined);
+        if (!this.isValidNumber(item[key].id) || item[key].name === undefined){
 
-      return itemResult;
+          return false;
 
-    },
-    ));
-    return result;
+        }
+  
+      }
+
+      return true;
+
+    }
+
+    return false;
 
   }
 
   private isValidNumber(item: unknown): item is number {
 
-    return (parseInt(item as string, 10) > 0);
+    return typeof item === 'number' && item > 0;
 
   }
 
   private isSet(item: unknown): item is Set<number> {
 
-    let result = false;
-
     if (item instanceof Set) {
 
-      result = Array.from(item).every(this.isValidNumber);
+      for (const entry of item) {
+        
+        if (!this.isValidNumber(entry)) {
+
+          return false;
+
+        }
+
+      }
+      
+      return true;
 
     }
 
-    return result;
+    return false;
 
   }
 
@@ -185,9 +198,10 @@ class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
     }
 
   }
+
   public empty(): void {
 
-    this.set_ = new Set<number>();
+    this.set_.clear();
 
   }
 
@@ -225,4 +239,5 @@ class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
   }
 
 }
+
 export {Vector};


### PR DESCRIPTION
* `core/src/encoder/Base64Url.ts`
  * replaced `Map` with an plain JSObject
* `core/src/encoder/field/LangEncoder.ts`
  * moved even check in `LangEncoder.encode`
  * moved `ASCII_START` to `LangEncoder.ASCII_START`
  * simplified `LangEncoder.decode` conditional branches
* `core/src/encoder/SegmentEncoder.ts`
  * added type `string[]` to "sequence" var in `SegmentEncoder.encode`
  * updated condition for "isPublisherCustom" in `SegmentEncoder.decode`
  * updated `SegmentEncoder.isPublisherCustom` implementation to use `String.startsWith`
  * renamed `key` variable to `field` in `SegmentEncoder.encode` and `SegmentEncoder.decode`
  * removed unecessary "toString" cast in `SegmentEncoder.fieldSequence` accessor
  * removed duplicate "version" parsing in `SegmentEncoder.decode`
  * removed `Number.isInteger` call from "TCModel[field].bitLength" check (since it's either a `number` or `undefined`)
* `core/src/model/Vector.ts`
  * updated implementation of `Vector.maxId` search
  * updated implementation of `isValidNumber`, which no longer (temporary) converts the given `item`
  * updated `Vector.empty` implementation to use `Set.clear` instead of allocating a new `Set`
  * updated `isSet` implementation, which no longer allocates an temporary array
  * updated `isIntMap` implementation to use "for...of" instead of `Array.every`

_be advised that i haven't run the tests locally_