### PR TITLE
Add missing status parameter for custom callbacks in the CmpApi documentation

### DIFF
--- a/modules/cmpapi/README.md
+++ b/modules/cmpapi/README.md
@@ -190,13 +190,13 @@ import {CmpApi} from '@iabtcf/cmpapi';
 
 const cmpApi = new CmpApi(1, 3, false, {
 
-  'getTCData': (next, tcData) => {
+  'getTCData': (next, tcData, status) => {
 
     // tcData will be constructed via the TC string and can be added to here
     tcData.reallyImportantExtraProperty = true;
 
-    // pass data along
-    next(tcData);
+    // pass data and status along
+    next(tcData, status);
 
 
   },


### PR DESCRIPTION
The documentation for custom handlers (for built-in commands) is missing the `status` parameter.

If `status` is not passed along `tcData` object to the `next` middleware, `status` will always have `undefined` value