### PR TITLE
accept null param in tcDataCommand

### DIFF
--- a/modules/cmpapi/src/command/GetTCDataCommand.ts
+++ b/modules/cmpapi/src/command/GetTCDataCommand.ts
@@ -18,7 +18,7 @@ export class GetTCDataCommand extends Command {
      * the array is not undefined and is an array of integers, otherwise it's
      * unusable
      */
-    if (this.param !== undefined &&
+    if ((this.param !== undefined || this.param !== null) &&
       (!Array.isArray(this.param) ||
        !this.param.every(Number.isInteger))) {
 


### PR DESCRIPTION
Recently added a customCommand for `getTCData`. Found I was getting the value `false` instead of the TCData object. Traced `false` down to a condition where the getTcDataCommand would throw an error based on value of this.param. Further down rabbit hole, found the postMessage handler in the cmpstub would return `null` as a value for the parameter (probably from an implementor passing null as the parameter value). This null value would cause GetTCDataCommand's validator to not pass and throw an error, resulting in a trickle down effect of false being passed instead of the TCData object. 

Could blame the implementing party for passing null, but I'd rather blame yavascript for being so "quirky" in its nully/falsey/undefinely values. So can we accept null as a param instead?