### PR TITLE
Call Built-In Custom Commands always with next function

### DIFF
--- a/modules/cmpapi/src/command/Command.ts
+++ b/modules/cmpapi/src/command/Command.ts
@@ -34,21 +34,15 @@ export abstract class Command {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected invokeCallback(response: any): void {
 
-    if (response !== null) {
+    const success = response !== null;
 
-      if (typeof this.next === 'function') {
+    if (typeof this.next === 'function') {
 
-        this.callback(this.next, response, true);
-
-      } else {
-
-        this.callback(response, true);
-
-      }
+      this.callback(this.next, response, success);
 
     } else {
 
-      this.callback(response, false);
+      this.callback(response, success);
 
     }
 


### PR DESCRIPTION
To be able to call the callback function in custom commands even though `tcData` is null. Discussed in this issue: https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/225