### PR TITLE
define gdprApplies once

### DIFF
--- a/modules/stub/src/stub.js
+++ b/modules/stub/src/stub.js
@@ -6,6 +6,7 @@
     const queue = [];
     let win = window;
     let cmpFrame;
+    let gdprApplies;
 
     function addFrame() {
 
@@ -35,8 +36,6 @@
     }
 
     function tcfAPIHandler(...args) {
-
-      let gdprApplies;
 
       if (!args.length) {
 


### PR DESCRIPTION
This fixes the issue brought up here in issue #232 where gdprApplies will be redefined every time you use the tcfapihandler 