### PR TITLE
Add validation to accept special purposes only vendors

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -58,8 +58,8 @@ export class SemanticPreEncoder {
               ) {
 
                 /**
-                 * Per June 2021 Policy change, Vendors declaring only Special Purposes may
-                 * have theirlegitimate interest Vendor bit set if they have been disclosed. 
+                 * Per June 2021 Policy change, Vendors declaring only Special Purposes must
+                 * have their legitimate interest Vendor bit set if they have been disclosed.
                  * This empty block ensures their LI bit remains set
                  */
 

--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -53,14 +53,14 @@ export class SemanticPreEncoder {
 
             } else if (vendor[gvlVendorKey].length === 0) {
 
-              // Define if the current vendor is special purposes only
-              const isSpecialPurposesOnly = vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0;
-
-              if (gvlVendorKey === 'legIntPurposes' && isSpecialPurposesOnly) {
+              if (
+                gvlVendorKey === 'legIntPurposes' && vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
+              ) {
 
                 /**
-                 * As special purposes have a special treatment and cannot being objected,
-                 * these special purposes only vendors need to set LI signal when present
+                 * Per June 2021 Policy change, Vendors declaring only Special Purposes may
+                 * have theirlegitimate interest Vendor bit set if they have been disclosed. 
+                 * This empty block ensures their LI bit remains set
                  */
 
               } else {

--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -41,8 +41,12 @@ export class SemanticPreEncoder {
           if (value) {
 
             const vendor = gvl.vendors[vendorId];
+            const isInactive = !vendor || vendor.deletedDate;
+            const isSpecialPurposesOnly = !isInactive
+              ? vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
+              : false;
 
-            if (!vendor || vendor.deletedDate) {
+            if (isInactive) {
 
               /**
                * If the vendor doesn't exist, then they should not receive a
@@ -125,6 +129,15 @@ export class SemanticPreEncoder {
 
               }
 
+            }
+
+            /**
+             * As special purposes have a special treatment and cannot being objected,
+             * these special purposes only vendors need to set LI signal when present
+             */
+
+            if (gvlVendorKey === 'legIntPurposes' && isSpecialPurposesOnly && !isInactive) {
+              vector.set(vendorId);
             }
 
           }

--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -41,12 +41,8 @@ export class SemanticPreEncoder {
           if (value) {
 
             const vendor = gvl.vendors[vendorId];
-            const isInactive = !vendor || vendor.deletedDate;
-            const isSpecialPurposesOnly = !isInactive
-              ? vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
-              : false;
 
-            if (isInactive) {
+            if (!vendor || vendor.deletedDate) {
 
               /**
                * If the vendor doesn't exist, then they should not receive a
@@ -57,87 +53,92 @@ export class SemanticPreEncoder {
 
             } else if (vendor[gvlVendorKey].length === 0) {
 
-              /**
-               * If the vendor does exist, but they haven't declared any
-               * purposes for this legal basis, then we need to see if they can
-               * possibly have the legal basis from their flexible purposes.
-               * This, of course, only matters if it is a globally-scoped string.
-               */
+              // Define if the current vendor is special purposes only
+              const isSpecialPurposesOnly = vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0;
 
-              if (tcModel.isServiceSpecific) {
+              if (gvlVendorKey === 'legIntPurposes' && isSpecialPurposesOnly) {
 
-                if (vendor.flexiblePurposes.length === 0) {
-
-                  /**
-                   * No flexible basis for any purposes, so we can safely remove
-                   * this vendor from the legal basis.
-                   */
-                  vector.unset(vendorId);
-
-                } else {
-
-                  /**
-                   * They have some flexible purposes, we should check for a
-                   * publisher restriction value that would enable this vendor to
-                   * have the override-preferred basis.
-                   */
-                  const restrictions = tcModel.publisherRestrictions.getRestrictions(vendorId);
-                  let isValid = false;
-
-                  for (let i = 0, len = restrictions.length; i < len && !isValid; i ++) {
-
-                    /**
-                     * If this condition is true the loop will break.  If we are
-                     * dealing with the consent purposes ('purposes') and the
-                     * publisher restriction overrides to consent then it is
-                     * valid for the vendor to have a positive signal for
-                     * consent.  Likewise for legitimate interest purposes
-                     * ('legIntPurposes') and requiring legitimate interest.
-                     */
-                    isValid = (
-                      (restrictions[i].restrictionType === RestrictionType.REQUIRE_CONSENT &&
-                      gvlVendorKey === 'purposes') ||
-                    (restrictions[i].restrictionType === RestrictionType.REQUIRE_LI &&
-                      gvlVendorKey === 'legIntPurposes'));
-
-                  }
-
-                  if (!isValid) {
-
-                    /**
-                     * if we came through the previous  loop without finding a
-                     * valid reasing: no overriding restrictions (changes in
-                     * legal basis) then it's not valid for this vendor to have
-                     * this legal basis.
-                     */
-
-                    vector.unset(vendorId);
-
-                  }
-
-                }
+                /**
+                 * As special purposes have a special treatment and cannot being objected,
+                 * these special purposes only vendors need to set LI signal when present
+                 */
 
               } else {
 
                 /**
-                 * This is a globally-scoped string so flexible purposes will not
-                 * be able to change this value because purposeRestrictions only
-                 * apply to service-specific strings.
+                 * If the vendor does exist, but they haven't declared any
+                 * purposes for this legal basis, then we need to see if they can
+                 * possibly have the legal basis from their flexible purposes.
+                 * This, of course, only matters if it is a globally-scoped string.
                  */
 
-                vector.unset(vendorId);
+                if (tcModel.isServiceSpecific) {
+
+                  if (vendor.flexiblePurposes.length === 0) {
+
+                    /**
+                     * No flexible basis for any purposes, so we can safely remove
+                     * this vendor from the legal basis.
+                     */
+                    vector.unset(vendorId);
+
+                  } else {
+
+                    /**
+                     * They have some flexible purposes, we should check for a
+                     * publisher restriction value that would enable this vendor to
+                     * have the override-preferred basis.
+                     */
+                    const restrictions = tcModel.publisherRestrictions.getRestrictions(vendorId);
+                    let isValid = false;
+
+                    for (let i = 0, len = restrictions.length; i < len && !isValid; i ++) {
+
+                      /**
+                       * If this condition is true the loop will break.  If we are
+                       * dealing with the consent purposes ('purposes') and the
+                       * publisher restriction overrides to consent then it is
+                       * valid for the vendor to have a positive signal for
+                       * consent.  Likewise for legitimate interest purposes
+                       * ('legIntPurposes') and requiring legitimate interest.
+                       */
+                      isValid = (
+                        (restrictions[i].restrictionType === RestrictionType.REQUIRE_CONSENT &&
+                        gvlVendorKey === 'purposes') ||
+                      (restrictions[i].restrictionType === RestrictionType.REQUIRE_LI &&
+                        gvlVendorKey === 'legIntPurposes'));
+
+                    }
+
+                    if (!isValid) {
+
+                      /**
+                       * if we came through the previous  loop without finding a
+                       * valid reasing: no overriding restrictions (changes in
+                       * legal basis) then it's not valid for this vendor to have
+                       * this legal basis.
+                       */
+
+                      vector.unset(vendorId);
+
+                    }
+
+                  }
+
+                } else {
+
+                  /**
+                   * This is a globally-scoped string so flexible purposes will not
+                   * be able to change this value because purposeRestrictions only
+                   * apply to service-specific strings.
+                   */
+
+                  vector.unset(vendorId);
+
+                }
 
               }
 
-            }
-
-            /**
-             * As special purposes have a special treatment and cannot being objected,
-             * these special purposes only vendors need to set LI signal when present
-             */
-
-            if (gvlVendorKey === 'legIntPurposes' && isSpecialPurposesOnly && !isInactive) {
-              vector.set(vendorId);
             }
 
           }

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -148,7 +148,15 @@ describe('TCString', (): void => {
 
       if (!vendor || (value && vendor.legIntPurposes.length === 0)) {
 
-        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
+        if (vendor && vendor.purposes.length === 0 && vendor.specialPurposes.length > 0) {
+
+          expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
+
+        } else {
+
+          expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
+
+        }
 
       } else {
 


### PR DESCRIPTION
PR linked to the issue reported on https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/288

Use case:

- In the Consent segment I'm trying to set one consent vendor and one special purposes vendor
- In the LI segment I'm trying to set one consent vendor, one LI vendor, one special purposes vendor, one deleted vendor

<pre>
const tcModel = new TCModel(new GVL());
tcModel.cmpId = 10;
tcModel.vendorConsents.set(952);
tcModel.vendorConsents.set(953);
tcModel.vendorLegitimateInterests.set(952);
tcModel.vendorLegitimateInterests.set(949);
tcModel.vendorLegitimateInterests.set(953);
tcModel.vendorLegitimateInterests.set(334);
</pre>

The result is the expected

![imagen](https://user-images.githubusercontent.com/16242913/123146897-099b0e80-d424-11eb-876c-aa9dbf6f970f.png)
