### PR TITLE
Reduce timestamp granularity in TC String

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -28,8 +28,8 @@ cmpId: 2
 cmpVersion: 1
 consentScreen: 2
 consentLanguage: "EN"
-created: Mon Dec 09 2019 18:01:46 GMT-0800 (Pacific Standard Time)
-lastUpdated: Mon Dec 09 2019 18:01:46 GMT-0800 (Pacific Standard Time)
+created: Mon Dec 09 2019 00:00:00 GMT
+lastUpdated: Mon Dec 09 2019 00:00:00 GMT
 policyVersion: 2
 isServiceSpecific: false
 useNonStandardStacks: false

--- a/modules/core/src/TCModel.ts
+++ b/modules/core/src/TCModel.ts
@@ -140,7 +140,6 @@ export class TCModel extends Cloneable<TCModel> {
 
     }
 
-    this.created = new Date();
     this.updated();
 
   }
@@ -691,13 +690,17 @@ export class TCModel extends Cloneable<TCModel> {
   }
 
   /**
-   * updated - updates the lastUpdatedDate with a 'now' timestamp
+   * updated - updates the created and lastUpdated dates with a 'now' day-level UTC timestamp
    *
    * @return {void}
    */
   public updated(): void {
 
-    this.lastUpdated = new Date();
+    const date = new Date();
+    const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
+    this.created = utcDate;
+    this.lastUpdated = utcDate;
 
   }
 

--- a/modules/testing/src/TCModelFactory.ts
+++ b/modules/testing/src/TCModelFactory.ts
@@ -38,11 +38,13 @@ export class TCModelFactory {
     tcModel.publisherCountryCode = String.fromCharCode(makeRandomInt(65, 90)) +
       String.fromCharCode(makeRandomInt(65, 90));
 
-    const now = (new Date()).getTime();
+    const date = new Date();
+    const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    const now = utcDate.getTime();
     const GDPRMageddon = 1576883249;
 
     tcModel.created = new Date(makeRandomInt(GDPRMageddon, now));
-    tcModel.lastUpdated = new Date(makeRandomInt(tcModel.created.getTime(), now));
+    tcModel.lastUpdated = new Date(makeRandomInt(GDPRMageddon, now));
 
     const mapping = {
       'purposes': [


### PR DESCRIPTION
This PR includes two changes :
- Set `created` with the same value as `lastUpdated` when updating the TC string
- Use a day-level UTC timestamp for both `created` and `lastUpdated`