### PR TITLE
[#357] Fix for some bundlers

### DIFF
--- a/modules/core/src/encoder/SegmentEncoder.ts
+++ b/modules/core/src/encoder/SegmentEncoder.ts
@@ -37,10 +37,11 @@ export class SegmentEncoder {
 
     }
 
+    const fieldEncoderMap = FieldEncoderMap();
     sequence.forEach((key: string): void => {
 
       const value: TCModelPropType = tcModel[key];
-      const encoder = FieldEncoderMap[key];
+      const encoder = fieldEncoderMap[key];
       let numBits: number = BitLength[key];
 
       if (numBits === undefined) {
@@ -94,9 +95,10 @@ export class SegmentEncoder {
 
     const sequence = this.fieldSequence[String(tcModel.version)][segment];
 
+    const fieldEncoderMap = FieldEncoderMap();
     sequence.forEach((key: string): void => {
 
-      const encoder = FieldEncoderMap[key];
+      const encoder = fieldEncoderMap[key];
       let numBits = BitLength[key];
 
       if (numBits === undefined) {

--- a/modules/core/src/encoder/field/FieldEncoderMap.ts
+++ b/modules/core/src/encoder/field/FieldEncoderMap.ts
@@ -7,35 +7,36 @@ import {LangEncoder} from './LangEncoder.js';
 import {PurposeRestrictionVectorEncoder} from './PurposeRestrictionVectorEncoder.js';
 import {VendorVectorEncoder} from './VendorVectorEncoder.js';
 
-export class FieldEncoderMap {
+export function FieldEncoderMap(): object {
 
-  public static readonly [Fields.version]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.created]: typeof DateEncoder = DateEncoder;
-  public static readonly [Fields.lastUpdated]: typeof DateEncoder = DateEncoder;
-  public static readonly [Fields.cmpId]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.cmpVersion]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.consentScreen]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.consentLanguage]: typeof LangEncoder = LangEncoder;
-  public static readonly [Fields.vendorListVersion]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.policyVersion]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.isServiceSpecific]: typeof BooleanEncoder = BooleanEncoder;
-  public static readonly [Fields.useNonStandardStacks]: typeof BooleanEncoder = BooleanEncoder;
-  public static readonly [Fields.specialFeatureOptins]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.purposeConsents]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.purposeLegitimateInterests]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.purposeOneTreatment]: typeof BooleanEncoder = BooleanEncoder;
-  public static readonly [Fields.publisherCountryCode]: typeof LangEncoder = LangEncoder;
-  public static readonly [Fields.vendorConsents]: typeof VendorVectorEncoder = VendorVectorEncoder;
-  public static readonly [Fields.vendorLegitimateInterests]: typeof VendorVectorEncoder = VendorVectorEncoder;
-  public static readonly [Fields.publisherRestrictions]: typeof PurposeRestrictionVectorEncoder
-  = PurposeRestrictionVectorEncoder;
-  public static readonly segmentType: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.vendorsDisclosed]: typeof VendorVectorEncoder = VendorVectorEncoder;
-  public static readonly [Fields.vendorsAllowed]: typeof VendorVectorEncoder = VendorVectorEncoder;
-  public static readonly [Fields.publisherConsents]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.publisherLegitimateInterests]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.numCustomPurposes]: typeof IntEncoder = IntEncoder;
-  public static readonly [Fields.publisherCustomConsents]: typeof FixedVectorEncoder = FixedVectorEncoder;
-  public static readonly [Fields.publisherCustomLegitimateInterests]: typeof FixedVectorEncoder = FixedVectorEncoder;
+  return {
+    [Fields.version]: IntEncoder,
+    [Fields.created]: DateEncoder,
+    [Fields.lastUpdated]: DateEncoder,
+    [Fields.cmpId]: IntEncoder,
+    [Fields.cmpVersion]: IntEncoder,
+    [Fields.consentScreen]: IntEncoder,
+    [Fields.consentLanguage]: LangEncoder,
+    [Fields.vendorListVersion]: IntEncoder,
+    [Fields.policyVersion]: IntEncoder,
+    [Fields.isServiceSpecific]: BooleanEncoder,
+    [Fields.useNonStandardStacks]: BooleanEncoder,
+    [Fields.specialFeatureOptins]: FixedVectorEncoder,
+    [Fields.purposeConsents]: FixedVectorEncoder,
+    [Fields.purposeLegitimateInterests]: FixedVectorEncoder,
+    [Fields.purposeOneTreatment]: BooleanEncoder,
+    [Fields.publisherCountryCode]: LangEncoder,
+    [Fields.vendorConsents]: VendorVectorEncoder,
+    [Fields.vendorLegitimateInterests]: VendorVectorEncoder,
+    [Fields.publisherRestrictions]: PurposeRestrictionVectorEncoder,
+    segmentType: IntEncoder,
+    [Fields.vendorsDisclosed]: VendorVectorEncoder,
+    [Fields.vendorsAllowed]: VendorVectorEncoder,
+    [Fields.publisherConsents]: FixedVectorEncoder,
+    [Fields.publisherLegitimateInterests]: FixedVectorEncoder,
+    [Fields.numCustomPurposes]: IntEncoder,
+    [Fields.publisherCustomConsents]: FixedVectorEncoder,
+    [Fields.publisherCustomLegitimateInterests]: FixedVectorEncoder,
+  };
 
 }


### PR DESCRIPTION
The implementation has the same effect as the previous one but solves problems related to the use of some bundlers.

Furthermore, it is also a very small optimization as FieldEncoderMap is as if it were a constant so you can easily call it outside the "foreach" thus avoiding repeating the same thing in each cycle.

@shortaflip Thanks in advance