### PR TITLE
[#374] Fix cjs output target with ES5

### DIFF
--- a/modules/cli/tsconfig-cjs.json
+++ b/modules/cli/tsconfig-cjs.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "lib/cjs",
     "module": "commonjs",
-    "target": "es2015"
+    "target": "ES5"
   },
   "exclude": [
     "node_modules"

--- a/modules/cmpapi/tsconfig-cjs.json
+++ b/modules/cmpapi/tsconfig-cjs.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "lib/cjs",
     "module": "commonjs",
-    "target": "es2015"
+    "target": "ES5"
   },
   "exclude": [
     "node_modules"

--- a/modules/core/tsconfig-cjs.json
+++ b/modules/core/tsconfig-cjs.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "lib/cjs",
     "module": "commonjs",
-    "target": "es2015"
+    "target": "ES5"
   },
   "exclude": [
     "node_modules"

--- a/modules/testing/tsconfig-cjs.json
+++ b/modules/testing/tsconfig-cjs.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "lib/cjs",
     "module": "commonjs",
-    "target": "es2015"
+    "target": "ES5"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
The goal of this PR:
- Fix the `cjs` output target by switching from `es2015` to `ES5` (target previously used)

closes #374 