### PR TITLE
[#378] Add CmpApiModel export

### DIFF
--- a/modules/cmpapi/src/index.ts
+++ b/modules/cmpapi/src/index.ts
@@ -2,5 +2,6 @@ export * from './command/index.js';
 export * from './response/index.js';
 export * from './status/index.js';
 export * from './CmpApi.js';
+export * from './CmpApiModel.js';
 export * from './CustomCommands.js';
 export {API_KEY, APIArgs} from './CallResponder.js';


### PR DESCRIPTION
The goal of the following PR:
Add `CmpApiModel` `export` inside `index.ts`

closes #378 