### PR TITLE
Add missing null check for post message data in cmp stub

### DIFF
--- a/modules/stub/src/stub.js
+++ b/modules/stub/src/stub.js
@@ -88,7 +88,7 @@
         json = event.data;
       }
 
-      const payload = (typeof json === 'object') ? json.__tcfapiCall : null;
+      const payload = (typeof json === 'object' && json !== null) ? json.__tcfapiCall : null;
 
       if (payload) {
         window.__tcfapi(


### PR DESCRIPTION
The CMP stub listens for all messages through its `postMessageEventHandler`, including messages unrelated with this library. As a result it can receive messages where `event.data` is `null`.

This case is currently not handled properly and the script crashes with the following error: `Uncaught TypeError: Cannot read properties of null (reading '__tcfapiCall')`.

This pull request adds the missing `null` check.