### PR TITLE
build binary search tree from the ordered number array

### DIFF
--- a/modules/core/src/model/BinarySearchTree.ts
+++ b/modules/core/src/model/BinarySearchTree.ts
@@ -12,6 +12,12 @@ export class BinarySearchTree extends Cloneable<BinarySearchTree> {
 
   private root: TreeNodeMaybe = null;
 
+  public getRoot(): TreeNodeMaybe {
+
+    return this.root;
+
+  }
+
   public isEmpty(): boolean {
 
     // if root is undefined or null then by definition this is empty
@@ -340,6 +346,61 @@ export class BinarySearchTree extends Cloneable<BinarySearchTree> {
         current = null;
 
       }
+
+    }
+
+  }
+
+  /**
+   * Build Binary Search Tree from the ordered number array
+   * @param {number[]} values number array in ascending order
+   * @return {BinarySearchTree} Binary Search Tree
+   */
+  static build(values?: number[]): BinarySearchTree | null {
+
+    if (!values || values.length === 0) {
+
+      return null;
+
+    } else if (values.length === 1) {
+
+      const tree = new BinarySearchTree();
+
+      tree.add(values[0]);
+
+      return tree;
+
+    } else {
+
+      const rootIndex = values.length >> 1;
+
+      const tree = new BinarySearchTree();
+
+      tree.add(values[rootIndex]);
+
+      const root = tree.getRoot();
+
+      if (root) {
+
+        if (rootIndex + 1 < values.length) {
+
+          const rightTree = BinarySearchTree.build(values.slice(rootIndex + 1));
+
+          root.right = rightTree ? rightTree.getRoot() : null;
+
+        }
+
+        if (rootIndex - 1 > 0 ) {
+
+          const leftTree = BinarySearchTree.build(values.slice(0, rootIndex - 1));
+
+          root.left = leftTree ? leftTree.getRoot(): null;
+
+        }
+
+      }
+
+      return tree;
 
     }
 

--- a/modules/core/src/model/BinarySearchTree.ts
+++ b/modules/core/src/model/BinarySearchTree.ts
@@ -352,7 +352,8 @@ export class BinarySearchTree extends Cloneable<BinarySearchTree> {
   }
 
   /**
-   * Build Binary Search Tree from the ordered number array
+   * Build Binary Search Tree from the ordered number array.
+   *  The depth of the tree will be the `log2` of the array length.
    * @param {number[]} values number array in ascending order
    * @return {BinarySearchTree} Binary Search Tree
    */

--- a/modules/core/src/model/PurposeRestrictionVector.ts
+++ b/modules/core/src/model/PurposeRestrictionVector.ts
@@ -148,13 +148,16 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
     })();
 
+    /**
+     * Create an ordered array of vendor IDs from `1` (the minimum value for Vendor ID) to `lastEntry`
+     */
     const values = [...Array(lastEntry).keys()].map( (i) => i + 1);
 
     for (let i = 1; i <= lastEntry; i++) {
 
       if (!this.has(hash)) {
 
-        this.map.set(hash, BinarySearchTree.build(values));
+        this.map.set(hash, BinarySearchTree.build(values)); // use static method `build` to create a `BST` from the ordered array of IDs
         this.bitLength = 0;
 
       }

--- a/modules/core/src/model/PurposeRestrictionVector.ts
+++ b/modules/core/src/model/PurposeRestrictionVector.ts
@@ -148,11 +148,13 @@ export class PurposeRestrictionVector extends Cloneable<PurposeRestrictionVector
 
     })();
 
+    const values = [...Array(lastEntry).keys()].map( (i) => i + 1);
+
     for (let i = 1; i <= lastEntry; i++) {
 
       if (!this.has(hash)) {
 
-        this.map.set(hash, new BinarySearchTree());
+        this.map.set(hash, BinarySearchTree.build(values));
         this.bitLength = 0;
 
       }

--- a/modules/core/test/Cloneable.test.ts
+++ b/modules/core/test/Cloneable.test.ts
@@ -1,11 +1,17 @@
 // import {Cloneable} from '../src/Cloneable';
+import {BinarySearchTree} from '../../core/src/model/BinarySearchTree';
 import {expect} from 'chai';
 
 describe('Cloneable', (): void => {
 
-  it('\x1b[36mNeeds Unit Tests\x1b[0m', (done: () => void): void => {
+  it('Clone BinarySearchTree', (done: () => void): void => {
 
-    expect(true).to.be.true;
+    const lastEntry = 4057;
+    const values = [...Array(lastEntry).keys()].map( (i) => i + 1);
+    const tree = BinarySearchTree.build(values);
+    expect(tree).to.be.a('object');
+
+    expect(tree?.clone()).to.be.a('object');
     done();
 
   });

--- a/modules/core/test/model/BinarySearchTree.test.ts
+++ b/modules/core/test/model/BinarySearchTree.test.ts
@@ -47,6 +47,18 @@ export function run(): void {
 
     });
 
+    it('should build tree from ordered array using static build method', (): void => {
+
+      const numItems = 40;
+      const values = getOrderedArray(numItems);
+      const bst = BinarySearchTree.build(values);
+
+      const result = bst?.get();
+
+      expect(result).to.deep.equal(values);
+
+    });
+
     it('should get() sorted array', (): void => {
 
       const numItems = 40;


### PR DESCRIPTION
In this PR we've implemented a static `build`  method  for `BinarySearchTree` class. We need to optimise the binary search tree depth that in the current implementation of the `restrictPurposeToLegalBasis` method  is equal to the number of vendors in the restriction and for vendors ids above `4056` we will hit the call stack limit in`Clonable.clone`.

The new `build`  method  will build  the search tree with depth equal to the `log2` of number of vendors. In this case `Clonable.clone` will work with vendors ids around `4056`  as the tree depth will be equal `12` and not `4056`.
## Changes 
- `getRoot` public method added to `BinarySearchTree` class;
- `build`  static method implemented;
- `restrictPurposeToLegalBasis` method updated to use `BinarySearchTree.build`;
- `Clonable.clone` test added;
-  `build`  test added.

