### PR TITLE
Validate callback is a function in CallResponder.apiCall

### DIFF
--- a/modules/cmpapi/src/CallResponder.ts
+++ b/modules/cmpapi/src/CallResponder.ts
@@ -97,7 +97,7 @@ export class CallResponder {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public apiCall(command: string, version: number, callback: CommandCallback, ...params: any): void | never {
 
-    if (typeof command !== 'string') {
+    if (typeof command !== 'string' && typeof callback === 'function') {
 
       callback(null, false);
 


### PR DESCRIPTION
We have been logging many errors where this callback is not a function. I assume this is due to incorrect usage of the cmpApi by one of our vendors. Here is a proposed fix. Let me know if I can provide anymore information.