### PR TITLE
Bump modules to 1.5.8

### DIFF
--- a/modules/cli/package.json
+++ b/modules/cli/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint `find src -name '*.ts'`"
   },
   "dependencies": {
-    "@iabtechlabtcf/core": "1.5.7"
+    "@iabtechlabtcf/core": "1.5.8"
   },
   "devDependencies": {
     "@types/node": "^17.0.18",

--- a/modules/cmpapi/package.json
+++ b/modules/cmpapi/package.json
@@ -31,8 +31,8 @@
     "@iabtechlabtcf/core": ">=1.0.0"
   },
   "devDependencies": {
-    "@iabtechlabtcf/stub": "1.5.7",
-    "@iabtechlabtcf/testing": "1.5.7",
+    "@iabtechlabtcf/stub": "1.5.8",
+    "@iabtechlabtcf/testing": "1.5.8",
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/mocha": "^9.1.0",
     "@types/sinon": "10.0.11",

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -28,7 +28,7 @@
     "test-cov": "rm -rf coverage; nyc --reporter=html mocha"
   },
   "devDependencies": {
-    "@iabtechlabtcf/testing": "1.5.7",
+    "@iabtechlabtcf/testing": "1.5.8",
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "3.2.8",


### PR DESCRIPTION
Bump modules to 1.5.8
Tests should stop failing
It closes https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/402