### PR TITLE
Support Language Welsh

### DIFF
--- a/modules/core/src/model/ConsentLanguages.ts
+++ b/modules/core/src/model/ConsentLanguages.ts
@@ -6,6 +6,7 @@ export class ConsentLanguages {
     'BS',
     'CA',
     'CS',
+    'CY',
     'DA',
     'DE',
     'EL',

--- a/modules/core/test/model/ConsentLanguages.test.ts
+++ b/modules/core/test/model/ConsentLanguages.test.ts
@@ -11,6 +11,7 @@ describe('model->ConsentLanguages', (): void => {
     'BS',
     'CA',
     'CS',
+    'CY',
     'DA',
     'DE',
     'EL',


### PR DESCRIPTION
IAB EU pushed support for language Welsh in TCF. This change will add Welsh (CY) to the list of support languages in the reference JS library.