### PR TITLE
Reset Vector.maxId_ field after Vector.empty().

### DIFF
--- a/modules/core/src/model/Vector.ts
+++ b/modules/core/src/model/Vector.ts
@@ -198,6 +198,7 @@ export class Vector extends Cloneable<Vector> implements Iterable<IdBoolTuple> {
   public empty(): void {
 
     this.set_ = new Set<number>();
+    this.maxId_ = 0;
 
   }
 


### PR DESCRIPTION
fixes #443 