### PR TITLE
Set consentLanguage without fetch request

### DIFF
--- a/modules/core/src/GVL.ts
+++ b/modules/core/src/GVL.ts
@@ -2,7 +2,7 @@ import {Cloneable} from './Cloneable.js';
 import {GVLError} from './errors/index.js';
 import {Json} from './Json.js';
 import {ConsentLanguages, IntMap} from './model/index.js';
-import {ByPurposeVendorMap, Declarations, Feature, IDSetMap, Purpose, Stack, Vendor, VendorList, DataCategory} from './model/gvl/index.js';
+import {ByPurposeVendorMap, Declarations, Feature, IDSetMap, Purpose, Stack, Vendor, VendorList, DataCategory, GvlCreationOptions} from './model/gvl/index.js';
 
 export type VersionOrVendorList = string | number | VendorList;
 type PurposeOrFeature = 'purpose' | 'feature';
@@ -236,8 +236,9 @@ export class GVL extends Cloneable<GVL> implements VendorList {
    * [[VendorList]] object or a version number represented as a string or
    * number to download.  If nothing is passed the latest version of the GVL
    * will be loaded
+   * @param options - it is an optional object where the default language can be set
    */
-  public constructor(versionOrVendorList?: VersionOrVendorList) {
+  public constructor(versionOrVendorList?: VersionOrVendorList, options?: GvlCreationOptions) {
 
     super();
 
@@ -247,8 +248,17 @@ export class GVL extends Cloneable<GVL> implements VendorList {
      */
     let url = GVL.baseUrl;
 
-    this.lang_ = GVL.DEFAULT_LANGUAGE;
-    this.cacheLang_ = GVL.DEFAULT_LANGUAGE;
+    let parsedLanguage: string = options?.language;
+    if (parsedLanguage) {
+      try {
+        parsedLanguage = GVL.consentLanguages.parseLanguage(parsedLanguage);
+      } catch (e) {
+        throw new GVLError('Error during parsing the language: ' + e.message);
+      }
+    }
+
+    this.lang_ = parsedLanguage || GVL.DEFAULT_LANGUAGE;
+    this.cacheLang_ = parsedLanguage || GVL.DEFAULT_LANGUAGE;
 
     if (this.isVendorList(versionOrVendorList as GVL)) {
 

--- a/modules/core/src/model/gvl/GvlCreationOptions.ts
+++ b/modules/core/src/model/gvl/GvlCreationOptions.ts
@@ -1,0 +1,3 @@
+export interface GvlCreationOptions {
+  language: string;
+}

--- a/modules/core/src/model/gvl/index.ts
+++ b/modules/core/src/model/gvl/index.ts
@@ -10,3 +10,4 @@ export * from './Stack.js';
 export * from './Vendor.js';
 export * from './VendorList.js';
 export * from './DataCategory.js';
+export * from './GvlCreationOptions.js';

--- a/modules/core/test/GVL.test.ts
+++ b/modules/core/test/GVL.test.ts
@@ -1,4 +1,4 @@
-import {expect} from 'chai';
+import {expect, assert} from 'chai';
 import * as sinon from 'sinon';
 import {GVL} from '../src/GVL';
 import {Vendor} from '../src/model/gvl';
@@ -10,6 +10,7 @@ import vendorListJson from '../../testing/lib/mjs/vendorlist/v2/vendor-list-v24.
 import translationJson from '../../testing/lib/mjs/vendorlist/v2/purposes-fr.json' assert { type: 'json' };
 import vendorListJson22 from '../../testing/lib/mjs/vendorlist/v2.2/vendor-list.json' assert { type: 'json' };
 import {VersionOrVendorList} from '../lib/mjs';
+import {GVLError} from '../src/errors/GVLError';
 
 const vendorlistJson: any = vendorListJson as unknown as VersionOrVendorList;
 const vendorlistJson22: any = vendorListJson22 as unknown as VersionOrVendorList;
@@ -126,6 +127,25 @@ describe('GVL', (): void => {
 
     assertPopulated(gvl, vendorlistJson22);
 
+  });
+
+  it('should create a new GVL with a valid language', (): void => {
+    const gvl: GVL = new GVL(vendorlistJson22, { language: 'ES' });
+
+    assertPopulated(gvl, vendorlistJson22);
+    expect(gvl.language).to.equal('ES');
+  });
+
+  it('should not create GVL object because with a invalid language', (): void => {
+    let gvl;
+    try {
+      gvl = new GVL(vendorlistJson22, { language: 'EQ' });
+    } catch (error) {
+      expect(error instanceof GVLError).to.equal(true);
+    } finally {
+      expect(gvl).to.equal(undefined);
+    }
+    assert.throws(() => new GVL(vendorlistJson22, { language: 'EQ' }), GVLError);
   });
 
   it('should clone all values', (): void => {
@@ -799,7 +819,7 @@ describe('GVL', (): void => {
 
           if (values && values.includes(intId)) {
 
-            expect(gvlMap[vendorId], `vendorId ${vendorId} should be in the map when ${gvlMethodName}() is called` )
+            expect(gvlMap[vendorId], `vendorId ${vendorId} should be in the map when ${gvlMethodName}() is called`)
               .to.not.be.undefined;
             expect(gvlMap[vendorId]).to.deep.equal(vendor);
 


### PR DESCRIPTION
Calling the changeLanguage method on the GVL class will trigger a new request, resulting in some 404 errors. There are a couple of open tickets related to this issue:

- Cant set consentLanguage with custom GVL #211
- GVL object is being constructed with the gvl json, and setting consentLanguage forces another fetch #405

We propose adding a boolean value to **SKIP** the fetch request.