### PR TITLE
Bug Fix: GVL file does not exist in built v2 vendor list folder

### DIFF
--- a/modules/testing/src/vendorlist/v2/vendor-list.json
+++ b/modules/testing/src/vendorlist/v2/vendor-list.json
@@ -1,1 +1,0 @@
-vendor-list-v51.json

--- a/modules/testing/src/vendorlist/v2/vendor-list.json
+++ b/modules/testing/src/vendorlist/v2/vendor-list.json
@@ -1,0 +1,13709 @@
+{
+    "gvlSpecificationVersion": 2,
+    "vendorListVersion": 51,
+    "tcfPolicyVersion": 2,
+    "lastUpdated": "2020-08-13T16:05:23Z",
+    "purposes": {
+        "1": {
+            "id": 1,
+            "name": "Store and/or access information on a device",
+            "description": "Cookies, device identifiers, or other information can be stored or accessed on your device for the purposes presented to you.",
+            "descriptionLegal": "Vendors can:\n* Store and access information on the device such as cookies and device identifiers presented to a user."
+        },
+        "2": {
+            "id": 2,
+            "name": "Select basic ads",
+            "description": "Ads can be shown to you based on the content you\u2019re viewing, the app you\u2019re using, your approximate location, or your device type.",
+            "descriptionLegal": "To do basic ad selection vendors can:\n* Use real-time information about the context in which the ad will be shown, to show the ad, including information about the content and the device, such as: device type and capabilities, user agent, URL, IP address\n* Use a user\u2019s non-precise geolocation data\n* Control the frequency of ads shown to a user.\n* Sequence the order in which ads are shown to a user.\n* Prevent an ad from serving in an unsuitable editorial (brand-unsafe) context\nVendors cannot:\n* Create a personalised ads profile using this information for the selection of future ads.\n* N.B. Non-precise means only an approximate location involving at least a radius of 500 meters is permitted."
+        },
+        "3": {
+            "id": 3,
+            "name": "Create a personalised ads profile",
+            "description": "A profile can be built about you and your interests to show you personalised ads that are relevant to you.",
+            "descriptionLegal": "To create a personalised ads profile vendors can:\n* Collect information about a user, including a user's activity, interests, demographic information, or location, to create or edit a user profile for use in personalised advertising.\n* Combine this information with other information previously collected, including from across websites and apps, to create or edit a user profile for use in personalised advertising."
+        },
+        "4": {
+            "id": 4,
+            "name": "Select personalised ads",
+            "description": "Personalised ads can be shown to you based on a profile about you.",
+            "descriptionLegal": "To select personalised ads vendors can:\n* Select personalised ads based on a user profile or other historical user data, including a user\u2019s prior activity, interests, visits to sites or apps, location, or demographic information."
+        },
+        "5": {
+            "id": 5,
+            "name": "Create a personalised content profile",
+            "description": "A profile can be built about you and your interests to show you personalised content that is relevant to you.",
+            "descriptionLegal": "To create a personalised content profile vendors can:\n* Collect information about a user, including a user's activity, interests, visits to sites or apps, demographic information, or location, to create or edit a user profile for personalising content.\n* Combine this information with other information previously collected, including from across websites and apps, to create or edit a user profile for use in personalising content."
+        },
+        "6": {
+            "id": 6,
+            "name": "Select personalised content",
+            "description": "Personalised content can be shown to you based on a profile about you.",
+            "descriptionLegal": "To select personalised content vendors can:\n* Select personalised content based on a user profile or other historical user data, including a user\u2019s prior activity, interests, visits to sites or apps, location, or demographic information."
+        },
+        "7": {
+            "id": 7,
+            "name": "Measure ad performance",
+            "description": "The performance and effectiveness of ads that you see or interact with can be measured.",
+            "descriptionLegal": "To measure ad performance vendors can:\n* Measure whether and how ads were delivered to and interacted with by a user\n* Provide reporting about ads including their effectiveness and performance\n* Provide reporting about users who interacted with ads using data observed during the course of the user's interaction with that ad\n* Provide reporting to publishers about the ads displayed on their property\n* Measure whether an ad is serving in a suitable editorial environment (brand-safe) context\n* Determine the percentage of the ad that had the opportunity to be seen and the duration of that opportunity\n* Combine this information with other information previously collected, including from across websites and apps\nVendors cannot:\n*Apply panel- or similarly-derived audience insights data to ad measurement data without a Legal Basis to apply market research to generate audience insights (Purpose 9)"
+        },
+        "8": {
+            "id": 8,
+            "name": "Measure content performance",
+            "description": "The performance and effectiveness of content that you see or interact with can be measured.",
+            "descriptionLegal": "To measure content performance vendors can:\n* Measure and report on how content was delivered to and interacted with by users.\n* Provide reporting, using directly measurable or known information, about users who interacted with the content\n* Combine this information with other information previously collected, including from across websites and apps.\nVendors cannot:\n* Measure whether and how ads (including native ads) were delivered to and interacted with by a user.\n* Apply panel- or similarly derived audience insights data to ad measurement data without a Legal Basis to apply market research to generate audience insights (Purpose 9)"
+        },
+        "9": {
+            "id": 9,
+            "name": "Apply market research to generate audience insights",
+            "description": "Market research can be used to learn more about the audiences who visit sites/apps and view ads.",
+            "descriptionLegal": "To apply market research to generate audience insights vendors can:\n* Provide aggregate reporting to advertisers or their representatives about the audiences reached by their ads, through panel-based and similarly derived insights.\n* Provide aggregate reporting to publishers about the audiences that were served or interacted with content and/or ads on their property by applying panel-based and similarly derived insights.\n* Associate offline data with an online user for the purposes of market research to generate audience insights if vendors have declared to match and combine offline data sources (Feature 1)\n* Combine this information with other information previously collected including from across websites and apps. \nVendors cannot:\n* Measure the performance and effectiveness of ads that a specific user was served or interacted with, without a Legal Basis to measure ad performance.\n* Measure which content a specific user was served and how they interacted with it, without a Legal Basis to measure content performance."
+        },
+        "10": {
+            "id": 10,
+            "name": "Develop and improve products",
+            "description": "Your data can be used to improve existing systems and software, and to develop new products",
+            "descriptionLegal": "To develop new products and improve products vendors can:\n* Use information to improve their existing products with new features and to develop new products\n* Create new models and algorithms through machine learning\nVendors cannot:\n* Conduct any other data processing operation allowed under a different purpose under this purpose"
+        }
+    },
+    "specialPurposes": {
+        "1": {
+            "id": 1,
+            "name": "Ensure security, prevent fraud, and debug",
+            "description": "Your data can be used to monitor for and prevent fraudulent activity, and ensure systems and processes work properly and securely.",
+            "descriptionLegal": "To ensure security, prevent fraud and debug vendors can:\n* Ensure data are securely transmitted\n* Detect and prevent malicious, fraudulent, invalid, or illegal activity.\n* Ensure correct and efficient operation of systems and processes, including to monitor and enhance the performance of systems and processes engaged in permitted purposes\nVendors cannot:\n* Conduct any other data processing operation allowed under a different purpose under this purpose."
+        },
+        "2": {
+            "id": 2,
+            "name": "Technically deliver ads or content",
+            "description": "Your device can receive and send information that allows you to see and interact with ads and content.",
+            "descriptionLegal": "To deliver information and respond to technical requests vendors can:\n* Use a user\u2019s IP address to deliver an ad over the internet\n* Respond to a user\u2019s interaction with an ad by sending the user to a landing page\n* Use a user\u2019s IP address to deliver content over the internet\n* Respond to a user\u2019s interaction with content by sending the user to a landing page\n* Use information about the device type and capabilities for delivering ads or content, for example, to deliver the right size ad creative or video file in a format supported by the device\nVendors cannot:\n* Conduct any other data processing operation allowed under a different purpose under this purpose"
+        }
+    },
+    "features": {
+        "1": {
+            "id": 1,
+            "name": "Match and combine offline data sources",
+            "description": "Data from offline data sources can be combined with your online activity in support of one or more purposes",
+            "descriptionLegal": "Vendors can:\n* Combine data obtained offline with data collected online in support of one or more Purposes or Special Purposes."
+        },
+        "2": {
+            "id": 2,
+            "name": "Link different devices",
+            "description": "Different devices can be determined as belonging to you or your household in support of one or more of purposes.",
+            "descriptionLegal": "Vendors can:\n* Deterministically determine that two or more devices belong to the same user or household\n* Probabilistically determine that two or more devices belong to the same user or household\n* Actively scan device characteristics for identification for probabilistic identification if users have allowed vendors to actively scan device characteristics for identification (Special Feature 2)"
+        },
+        "3": {
+            "id": 3,
+            "name": "Receive and use automatically-sent device characteristics for identification",
+            "description": "Your device might be distinguished from other devices based on information it automatically sends, such as IP address or browser type.",
+            "descriptionLegal": "Vendors can:\n* Create an identifier using data collected automatically from a device for specific characteristics, e.g. IP address, user-agent string.\n* Use such an identifier to attempt to re-identify a device.\nVendors cannot:\n* Create an identifier using data collected via actively scanning a device for specific characteristics, e.g. installed font or screen resolution without users\u2019 separate opt-in to actively scanning device characteristics for identification.\n* Use such an identifier to re-identify a device."
+        }
+    },
+    "specialFeatures": {
+        "1": {
+            "id": 1,
+            "name": "Use precise geolocation data",
+            "description": "Your precise geolocation data can be used in support of one or more purposes. This means your location can be accurate to within several meters.",
+            "descriptionLegal": "Vendors can:\n* Collect and process precise geolocation data in support of one or more purposes.\nN.B. Precise geolocation means that there are no restrictions on the precision of a user\u2019s location; this can be accurate to within several meters."
+        },
+        "2": {
+            "id": 2,
+            "name": "Actively scan device characteristics for identification",
+            "description": "Your device can be identified based on a scan of your device's unique combination of characteristics.",
+            "descriptionLegal": "Vendors can:\n* Create an identifier using data collected via actively scanning a device for specific characteristics, e.g. installed fonts or screen resolution.\n* Use such an identifier to re-identify a device."
+        }
+    },
+    "stacks": {
+        "1": {
+            "id": 1,
+            "purposes": [],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "name": "Precise geolocation data, and identification through device scanning",
+            "description": "Precise geolocation and information about device characteristics can be used."
+        },
+        "2": {
+            "id": 2,
+            "purposes": [
+                2,
+                7
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, and ad measurement",
+            "description": "Basic ads can be served. Ad performance can be measured."
+        },
+        "3": {
+            "id": 3,
+            "purposes": [
+                2,
+                3,
+                4
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads."
+        },
+        "4": {
+            "id": 4,
+            "purposes": [
+                2,
+                7,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, ad measurement, and audience insights",
+            "description": "Basic ads can be served. Ad performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "5": {
+            "id": 5,
+            "purposes": [
+                2,
+                3,
+                7
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised ads profile, and ad measurement",
+            "description": "Basic ads can be served. More data can be added to better personalise ads. Ad performance can be measured."
+        },
+        "6": {
+            "id": 6,
+            "purposes": [
+                2,
+                4,
+                7
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads display and ad measurement",
+            "description": "Ads can be personalised based on a profile. Ad performance can be measured."
+        },
+        "7": {
+            "id": 7,
+            "purposes": [
+                2,
+                4,
+                7,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads display, ad measurement, and audience insights",
+            "description": "Ads can be personalised based on a profile. Ad performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "8": {
+            "id": 8,
+            "purposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, and ad measurement",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads. Ad performance can be measured."
+        },
+        "9": {
+            "id": 9,
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, ad measurement, and audience insights",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads. Ad performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "10": {
+            "id": 10,
+            "purposes": [
+                3,
+                4
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads profile and display",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads."
+        },
+        "11": {
+            "id": 11,
+            "purposes": [
+                5,
+                6
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content",
+            "description": "Content can be personalised based on a profile. More data can be added to better personalise content."
+        },
+        "12": {
+            "id": 12,
+            "purposes": [
+                6,
+                8
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content display, and content measurement",
+            "description": "Content can be personalised based on a profile. Content performance can be measured."
+        },
+        "13": {
+            "id": 13,
+            "purposes": [
+                6,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content display, content measurement and audience insights",
+            "description": "Content can be personalised based on a profile. Content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "14": {
+            "id": 14,
+            "purposes": [
+                5,
+                6,
+                8
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content, and content measurement",
+            "description": "Content can be personalised based on a profile. More data can be added to better personalise content. Content performance can be measured."
+        },
+        "15": {
+            "id": 15,
+            "purposes": [
+                5,
+                6,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content, content measurement and audience insights",
+            "description": "Content can be personalised based on a profile. More data can be added to better personalise content. Content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "16": {
+            "id": 16,
+            "purposes": [
+                5,
+                6,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised content, content measurement, audience insights, and product development",
+            "description": "Content can be personalised based on a profile. More data can be added to better personalise content. Content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software"
+        },
+        "17": {
+            "id": 17,
+            "purposes": [
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Ad and content measurement, and audience insights",
+            "description": "Ad and content performance can be measured.  Insights about the audiences who saw the ads and content can be derived."
+        },
+        "18": {
+            "id": 18,
+            "purposes": [
+                7,
+                8
+            ],
+            "specialFeatures": [],
+            "name": "Ad and content measurement",
+            "description": "Ad and content performance can be measured."
+        },
+        "19": {
+            "id": 19,
+            "purposes": [
+                7,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Ad measurement, and audience insights",
+            "description": "Ad can be measured.  Insights about the audiences who saw the ads and content can be derived."
+        },
+        "20": {
+            "id": 20,
+            "purposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Ad and content measurement, audience insights, and product development",
+            "description": "Ad and content performance can be measured.  Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "21": {
+            "id": 21,
+            "purposes": [
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Content measurement, audience insights, and product development.",
+            "description": "Content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software."
+        },
+        "22": {
+            "id": 22,
+            "purposes": [
+                8,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Content measurement, and product development",
+            "description": "Content performance can be measured. Data can be used to build or improve user experience, systems, and software."
+        },
+        "23": {
+            "id": 23,
+            "purposes": [
+                2,
+                4,
+                6,
+                7,
+                8
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content display, ad and content measurement",
+            "description": "Ads and content can be personalised based on a profile. Ad and content performance can be measured."
+        },
+        "24": {
+            "id": 24,
+            "purposes": [
+                2,
+                4,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content display, ad and content measurement, and audience insights",
+            "description": "Ads and content can be personalised based on a profile. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software."
+        },
+        "25": {
+            "id": 25,
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content, ad and content measurement",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise ads and content. Ad and content performance can be measured."
+        },
+        "26": {
+            "id": 26,
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content, ad and content measurement, and audience insights",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise ads and content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "27": {
+            "id": 27,
+            "purposes": [
+                3,
+                5
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, and content profile",
+            "description": "More data can be added to personalise ads and content."
+        },
+        "28": {
+            "id": 28,
+            "purposes": [
+                2,
+                4,
+                6
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content display",
+            "description": "Ads and content can be personalised based on a profile."
+        },
+        "29": {
+            "id": 29,
+            "purposes": [
+                2,
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, ad and content measurement, and audience insights",
+            "description": "Basic ads can be served. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "30": {
+            "id": 30,
+            "purposes": [
+                2,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads display, personalised content, ad and content measurement, and audience insights",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "31": {
+            "id": 31,
+            "purposes": [
+                2,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads display, personalised content, ad and content measurement, audience insights, and product development",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software."
+        },
+        "32": {
+            "id": 32,
+            "purposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, ad and content measurement, and audience insights",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "33": {
+            "id": 33,
+            "purposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, ad and content measurement, audience insights, and product development",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software."
+        },
+        "34": {
+            "id": 34,
+            "purposes": [
+                2,
+                5,
+                6,
+                8,
+                9
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, content measurement, and audience insights",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Ad and content performance can be measured. Insights about the audiences who saw the ads and content can be derived."
+        },
+        "35": {
+            "id": 35,
+            "purposes": [
+                2,
+                5,
+                6,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, content measurement, audience insights, and product development",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Content performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems, and software."
+        },
+        "36": {
+            "id": 36,
+            "purposes": [
+                2,
+                5,
+                6,
+                7
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, and ad measurement",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Ad performance can be measured."
+        },
+        "37": {
+            "id": 37,
+            "purposes": [
+                2,
+                5,
+                6,
+                7,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Basic ads, personalised content, ad measurement, and product development",
+            "description": "Basic ads can be served. Content can be personalised based on a profile. More data can be added to better personalise content. Ad performance can be measured. Data can be used to build or improve user experience, systems, and software."
+        },
+        "38": {
+            "id": 38,
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, ad measurement, and product development",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads. Ad performance can be measured. Data can be used to build or improve user experience, systems, and software."
+        },
+        "39": {
+            "id": 39,
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, ad measurement, audience insights and product development",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads. Ad performance can be measured. Insights about the audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems and software."
+        },
+        "40": {
+            "id": 40,
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, ad and content measurement, audience insights and product development",
+            "description": "Ads can be personalised based on a profile. More data can be added to better personalise ads. Ad and content performance can be measured. Insights about audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems and software."
+        },
+        "41": {
+            "id": 41,
+            "purposes": [
+                2,
+                3,
+                4,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads, personalised content display, ad and content measurement, audience insights and product development",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise ads. Ad and content performance can be measured. Insights about audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems and software."
+        },
+        "42": {
+            "id": 42,
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialFeatures": [],
+            "name": "Personalised ads and content, ad and content measurement, audience insights and product development",
+            "description": "Ads and content can be personalised based on a profile. More data can be added to better personalise ads and content. Ad and content performance can be measured. Insights about audiences who saw the ads and content can be derived. Data can be used to build or improve user experience, systems and software."
+        }
+    },
+    "vendors": {
+        "8": {
+            "id": 8,
+            "name": "Emerse Sverige AB",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9
+            ],
+            "flexiblePurposes": [
+                2,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.emerse.com/privacy-policy/"
+        },
+        "9": {
+            "id": 9,
+            "name": "AdMaxim Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.admaxim.com/admaxim-privacy-policy/",
+            "deletedDate": "2020-06-17T00:00:00Z"
+        },
+        "12": {
+            "id": 12,
+            "name": "BeeswaxIO Corporation",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.beeswax.com/privacy/"
+        },
+        "28": {
+            "id": 28,
+            "name": "TripleLift, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://triplelift.com/privacy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "25": {
+            "id": 25,
+            "name": "Verizon Media EMEA Limited",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.verizonmedia.com/policies/ie/en/verizonmedia/privacy/index.html"
+        },
+        "26": {
+            "id": 26,
+            "name": "Venatus Media Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.venatusmedia.com/privacy/"
+        },
+        "1": {
+            "id": 1,
+            "name": "Exponential Interactive, Inc d/b/a VDX.tv",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://vdx.tv/privacy/"
+        },
+        "6": {
+            "id": 6,
+            "name": "AdSpirit GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.adspirit.de/privacy",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "30": {
+            "id": 30,
+            "name": "BidTheatre AB",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.bidtheatre.com/privacy-policy"
+        },
+        "24": {
+            "id": 24,
+            "name": "Epsilon",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.conversantmedia.eu/legal/privacy-policy"
+        },
+        "39": {
+            "id": 39,
+            "name": "ADITION technologies AG",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adition.com/datenschutz"
+        },
+        "11": {
+            "id": 11,
+            "name": "Quantcast International Limited",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.quantcast.com/privacy/"
+        },
+        "15": {
+            "id": 15,
+            "name": "Adikteev",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adikteev.com/privacy-policy-eng/"
+        },
+        "4": {
+            "id": 4,
+            "name": "Roq.ad Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.roq.ad/privacy-policy"
+        },
+        "7": {
+            "id": 7,
+            "name": "Vibrant Media Limited",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.vibrantmedia.com/en/privacy-policy/"
+        },
+        "2": {
+            "id": 2,
+            "name": "Captify Technologies Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.captify.co.uk/privacy-policy/"
+        },
+        "37": {
+            "id": 37,
+            "name": "NEURAL.ONE",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://web.neural.one/privacy-policy/"
+        },
+        "13": {
+            "id": 13,
+            "name": "Sovrn Holdings Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.sovrn.com/sovrn-privacy/"
+        },
+        "34": {
+            "id": 34,
+            "name": "NEORY GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.neory.com/privacy.html",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "32": {
+            "id": 32,
+            "name": "Xandr, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.xandr.com/privacy/platform-privacy-policy/"
+        },
+        "10": {
+            "id": 10,
+            "name": "Index Exchange, Inc. ",
+            "purposes": [
+                1,
+                2,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.indexexchange.com/privacy"
+        },
+        "57": {
+            "id": 57,
+            "name": "ADARA MEDIA UNLIMITED",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://adara.com/privacy-promise/"
+        },
+        "63": {
+            "id": 63,
+            "name": "Avocet Systems Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://avocet.io/privacy-portal"
+        },
+        "51": {
+            "id": 51,
+            "name": "xAd, Inc. dba GroundTruth",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.groundtruth.com/privacy-policy/"
+        },
+        "49": {
+            "id": 49,
+            "name": "TRADELAB",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://tradelab.com/en/privacy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "45": {
+            "id": 45,
+            "name": "Smart Adserver",
+            "purposes": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://smartadserver.com/end-user-privacy-policy/"
+        },
+        "52": {
+            "id": 52,
+            "name": "The Rubicon Project, Inc. ",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.rubiconproject.com/rubicon-project-yield-optimization-privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "71": {
+            "id": 71,
+            "name": "Roku Advertising Services",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://docs.roku.com/published/userprivacypolicy/en/us"
+        },
+        "79": {
+            "id": 79,
+            "name": "MediaMath, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.mediamath.com/privacy-policy/"
+        },
+        "91": {
+            "id": 91,
+            "name": "Criteo SA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.criteo.com/privacy/"
+        },
+        "85": {
+            "id": 85,
+            "name": "Crimtan Holdings Limited",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://crimtan.com/privacy/"
+        },
+        "16": {
+            "id": 16,
+            "name": "RTB House S.A.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.rtbhouse.com/privacy-center/services-privacy-policy/"
+        },
+        "86": {
+            "id": 86,
+            "name": "Scene Stealer Limited",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://scenestealer.tv/privacy-policy/"
+        },
+        "94": {
+            "id": 94,
+            "name": "Blis Media Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.blis.com/privacy/"
+        },
+        "73": {
+            "id": 73,
+            "name": "Simplifi Holdings Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4
+            ],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://simpli.fi/site-privacy-policy/"
+        },
+        "33": {
+            "id": 33,
+            "name": "ShareThis, Inc",
+            "purposes": [
+                1,
+                3,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://sharethis.com/privacy/"
+        },
+        "20": {
+            "id": 20,
+            "name": "N Technologies Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://n.rich/privacy-notice"
+        },
+        "53": {
+            "id": 53,
+            "name": "Sirdata",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.sirdata.com/privacy/"
+        },
+        "69": {
+            "id": 69,
+            "name": "OpenX",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.openx.com/legal/privacy-policy/"
+        },
+        "98": {
+            "id": 98,
+            "name": "GroupM UK Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.groupm.com/privacy-notice"
+        },
+        "62": {
+            "id": 62,
+            "name": "Justpremium BV",
+            "purposes": [
+                1,
+                4,
+                5,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://justpremium.com/privacy-policy/"
+        },
+        "36": {
+            "id": 36,
+            "name": "RhythmOne DBA Unruly Group Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.rhythmone.com/privacy-policy"
+        },
+        "80": {
+            "id": 80,
+            "name": "Sharethrough, Inc",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://platform-cdn.sharethrough.com/privacy-policy"
+        },
+        "23": {
+            "id": 23,
+            "name": "Amobee, Inc. ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.amobee.com/trust/privacy-guidelines"
+        },
+        "67": {
+            "id": 67,
+            "name": "LifeStreet Corporation",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://lifestreet.com/privacy/"
+        },
+        "68": {
+            "id": 68,
+            "name": "Sizmek by Amazon",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.sizmek.com/privacy-policy/"
+        },
+        "61": {
+            "id": 61,
+            "name": "GumGum, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://gumgum.com/privacy-policy"
+        },
+        "40": {
+            "id": 40,
+            "name": "Active Agent (ADITION technologies AG)",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.active-agent.com/de/unternehmen/datenschutzerklaerung/"
+        },
+        "76": {
+            "id": 76,
+            "name": "PubMatic, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://pubmatic.com/privacy-policy/"
+        },
+        "89": {
+            "id": 89,
+            "name": "Tapad, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.tapad.com/eu-privacy-policy"
+        },
+        "66": {
+            "id": 66,
+            "name": "adsquare GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adsquare.com/privacy"
+        },
+        "41": {
+            "id": 41,
+            "name": "Adverline",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adverline.com/privacy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "82": {
+            "id": 82,
+            "name": "Smaato, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.smaato.com/privacy/"
+        },
+        "60": {
+            "id": 60,
+            "name": "Rakuten Marketing LLC",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://rakutenadvertising.com/legal-notices/services-privacy-policy/"
+        },
+        "70": {
+            "id": 70,
+            "name": "Yieldlab AG",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.yieldlab.de/meta-navigation/datenschutz/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "50": {
+            "id": 50,
+            "name": "Adform",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://site.adform.com/privacy-center/platform-privacy/product-and-services-privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "100": {
+            "id": 100,
+            "name": "Fifty Technology Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://fifty.io/privacy-policy.php"
+        },
+        "21": {
+            "id": 21,
+            "name": "The Trade Desk",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.thetradedesk.com/general/privacy-policy"
+        },
+        "110": {
+            "id": 110,
+            "name": "Dynata LLC",
+            "purposes": [
+                1,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.opinionoutpost.co.uk/en-gb/policies/privacy"
+        },
+        "42": {
+            "id": 42,
+            "name": "Taboola Europe Limited",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.taboola.com/privacy-policy"
+        },
+        "77": {
+            "id": 77,
+            "name": "comScore, Inc.",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.scorecardresearch.com/privacy.aspx?newlanguage=1"
+        },
+        "109": {
+            "id": 109,
+            "name": "LoopMe Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://loopme.com/privacy-policy/"
+        },
+        "120": {
+            "id": 120,
+            "name": "Eyeota Pte Ltd",
+            "purposes": [
+                1,
+                3,
+                5,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                5,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.eyeota.com/privacy-center"
+        },
+        "93": {
+            "id": 93,
+            "name": "Adloox SA",
+            "purposes": [],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://adloox.com/disclaimer",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "132": {
+            "id": 132,
+            "name": "Teads ",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.teads.com/privacy-policy/"
+        },
+        "22": {
+            "id": 22,
+            "name": "admetrics GmbH",
+            "purposes": [
+                2,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://admetrics.io/en/privacy_policy/"
+        },
+        "102": {
+            "id": 102,
+            "name": "Telaria SAS",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://telaria.com/privacy-policy/"
+        },
+        "108": {
+            "id": 108,
+            "name": "Rich Audience Technologies SL",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://richaudience.com/privacy/"
+        },
+        "18": {
+            "id": 18,
+            "name": "Widespace AB",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.widespace.com/legal/privacy-policy-notice/"
+        },
+        "122": {
+            "id": 122,
+            "name": "Avid Media Ltd",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.avidglobalmedia.eu/privacy-policy.html"
+        },
+        "97": {
+            "id": 97,
+            "name": "LiveRamp, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.liveramp.com/service-privacy-policy/"
+        },
+        "138": {
+            "id": 138,
+            "name": "ConnectAd Realtime GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://connectadrealtime.com/privacy/"
+        },
+        "72": {
+            "id": 72,
+            "name": "Nano Interactive GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.nanointeractive.com/privacy"
+        },
+        "127": {
+            "id": 127,
+            "name": "PIXIMEDIA SAS",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://piximedia.com/privacy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "136": {
+            "id": 136,
+            "name": "Str\u00f6er SSP GmbH (SSP)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf"
+        },
+        "111": {
+            "id": 111,
+            "name": "Showheroes SE",
+            "purposes": [
+                1,
+                3,
+                4,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://showheroes.com/privacy/"
+        },
+        "124": {
+            "id": 124,
+            "name": "Teemo SA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://teemo.co/fr/confidentialite/"
+        },
+        "154": {
+            "id": 154,
+            "name": "YOC AG",
+            "purposes": [
+                1,
+                3,
+                4,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://yoc.com/privacy/"
+        },
+        "101": {
+            "id": 101,
+            "name": "MiQ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://wearemiq.com/privacy-policy/"
+        },
+        "149": {
+            "id": 149,
+            "name": "ADman Interactive SLU",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://admanmedia.com/politica.html?setLng=es"
+        },
+        "153": {
+            "id": 153,
+            "name": "MADVERTISE MEDIA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                5,
+                6,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://madvertise.com/en/gdpr/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "157": {
+            "id": 157,
+            "name": "Seedtag Advertising S.L",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.seedtag.com/en/privacy-policy/"
+        },
+        "145": {
+            "id": 145,
+            "name": "Snapsort Inc., operating as Sortable",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://help.sortable.com/help/privacy-policy"
+        },
+        "131": {
+            "id": 131,
+            "name": "ID5 Technology SAS",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.id5.io/privacy"
+        },
+        "158": {
+            "id": 158,
+            "name": "Reveal Mobile, Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://revealmobile.com/privacy"
+        },
+        "147": {
+            "id": 147,
+            "name": "Adacado Technologies Inc. (DBA Adacado)",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adacado.com/privacy-policy-april-25-2018/"
+        },
+        "130": {
+            "id": 130,
+            "name": "NextRoll, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.nextroll.com/privacy"
+        },
+        "129": {
+            "id": 129,
+            "name": "IPONWEB GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.iponweb.com/privacy-policy/"
+        },
+        "128": {
+            "id": 128,
+            "name": "BIDSWITCH GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.bidswitch.com/privacy-policy/"
+        },
+        "168": {
+            "id": 168,
+            "name": "EASYmedia GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://login.rtbmarket.com/gdpr"
+        },
+        "164": {
+            "id": 164,
+            "name": "Outbrain UK Ltd",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.outbrain.com/legal/privacy#privacy-policy"
+        },
+        "144": {
+            "id": 144,
+            "name": "district m inc.",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://districtm.net/en/page/platforms-data-and-privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "163": {
+            "id": 163,
+            "name": "Bombora Inc.",
+            "purposes": [
+                1,
+                3,
+                8
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://bombora.com/privacy"
+        },
+        "173": {
+            "id": 173,
+            "name": "Yieldmo, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.yieldmo.com/privacy/"
+        },
+        "88": {
+            "id": 88,
+            "name": "TreSensa, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.tresensa.com/eu-privacy"
+        },
+        "78": {
+            "id": 78,
+            "name": "Flashtalking, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.flashtalking.com/privacypolicy/"
+        },
+        "59": {
+            "id": 59,
+            "name": "Sift Media, Inc",
+            "purposes": [
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.sift.co/privacy"
+        },
+        "114": {
+            "id": 114,
+            "name": "Sublime",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://ayads.co/privacy.php"
+        },
+        "133": {
+            "id": 133,
+            "name": "digitalAudience",
+            "purposes": [
+                1,
+                3,
+                5,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://digitalaudience.io/legal/privacy-cookies/"
+        },
+        "14": {
+            "id": 14,
+            "name": "Adkernel LLC",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9
+            ],
+            "flexiblePurposes": [
+                3,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://adkernel.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "183": {
+            "id": 183,
+            "name": "EMX Digital LLC",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://emxdigital.com/privacy/"
+        },
+        "58": {
+            "id": 58,
+            "name": "33Across",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.33across.com/privacy-policy"
+        },
+        "140": {
+            "id": 140,
+            "name": "Platform161",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://platform161.com/cookie-and-privacy-policy/"
+        },
+        "90": {
+            "id": 90,
+            "name": "Teroa S.A.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.e-planning.net/en/privacy.html"
+        },
+        "141": {
+            "id": 141,
+            "name": "1020, Inc. dba Placecast and Ericsson Emodo",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.emodoinc.com/privacy-policy/"
+        },
+        "142": {
+            "id": 142,
+            "name": "Media.net Advertising FZ-LLC",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                5,
+                6,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.media.net/en/privacy-policy"
+        },
+        "209": {
+            "id": 209,
+            "name": "Delta Projects AB",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://deltaprojects.com/data-collection-policy"
+        },
+        "195": {
+            "id": 195,
+            "name": "advanced store GmbH",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.advanced-store.com/de/datenschutz/"
+        },
+        "190": {
+            "id": 190,
+            "name": "video intelligence AG",
+            "purposes": [],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.vi.ai/privacy-policy/"
+        },
+        "84": {
+            "id": 84,
+            "name": "Semasio GmbH",
+            "purposes": [
+                1,
+                3,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.semasio.com/privacy-policy/"
+        },
+        "65": {
+            "id": 65,
+            "name": "Location Sciences AI Ltd",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.locationsciences.ai/privacy-policy/"
+        },
+        "210": {
+            "id": 210,
+            "name": "Zemanta, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                3,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.zemanta.com/legal/privacy"
+        },
+        "200": {
+            "id": 200,
+            "name": "Tapjoy, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.tapjoy.com/legal/#privacy-policy"
+        },
+        "217": {
+            "id": 217,
+            "name": "2KDirect, Inc. (dba iPromote)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.ipromote.com/privacy-policy/"
+        },
+        "194": {
+            "id": 194,
+            "name": "Rezonence Limited",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://rezonence.com/privacy-policy/"
+        },
+        "226": {
+            "id": 226,
+            "name": "Publicis Media GmbH",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.publicismedia.de/datenschutz/"
+        },
+        "227": {
+            "id": 227,
+            "name": "ORTEC B.V.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ortecadscience.com/privacy-policy/"
+        },
+        "205": {
+            "id": 205,
+            "name": "Adssets AB",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                8,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://adssets.com/policy/"
+        },
+        "179": {
+            "id": 179,
+            "name": "Collective Europe Ltd.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.collectiveuk.com/privacy.html",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "31": {
+            "id": 31,
+            "name": "Ogury Ltd.",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.ogury.com/privacy-policy/"
+        },
+        "92": {
+            "id": 92,
+            "name": "1plusX AG",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.1plusx.com/privacy-policy/"
+        },
+        "155": {
+            "id": 155,
+            "name": "AntVoice",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.antvoice.com/en/privacypolicy/"
+        },
+        "115": {
+            "id": 115,
+            "name": "smartclip Europe GmbH",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://privacy-portal.smartclip.net/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "126": {
+            "id": 126,
+            "name": "DoubleVerify Inc.\u200b",
+            "purposes": [
+                2,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.doubleverify.com/privacy/"
+        },
+        "193": {
+            "id": 193,
+            "name": "Mediasmart Mobile S.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://mediasmart.io/privacy/"
+        },
+        "213": {
+            "id": 213,
+            "name": "emetriq GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.emetriq.com/datenschutz/"
+        },
+        "244": {
+            "id": 244,
+            "name": "Temelio",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://temelio.com/vie-privee"
+        },
+        "224": {
+            "id": 224,
+            "name": "adrule mobile GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                8
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adrule.net/de/datenschutz/"
+        },
+        "174": {
+            "id": 174,
+            "name": "A Million Ads Ltd",
+            "purposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.amillionads.com/privacy-policy"
+        },
+        "192": {
+            "id": 192,
+            "name": "remerge GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://remerge.io/privacy-policy.html"
+        },
+        "256": {
+            "id": 256,
+            "name": "Bounce Exchange, Inc",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.bouncex.com/privacy/"
+        },
+        "234": {
+            "id": 234,
+            "name": "ZBO Media",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://zbo.media/mentions-legales/politique-de-confidentialite-service-publicitaire/"
+        },
+        "246": {
+            "id": 246,
+            "name": "Smartology Limited",
+            "purposes": [
+                1,
+                3,
+                4,
+                8
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.smartology.net/privacy-policy/"
+        },
+        "241": {
+            "id": 241,
+            "name": "OneTag Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.onetag.com/privacy/"
+        },
+        "254": {
+            "id": 254,
+            "name": "LiquidM Technology GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://liquidm.com/privacy-policy/"
+        },
+        "215": {
+            "id": 215,
+            "name": "ARMIS SAS",
+            "purposes": [
+                1,
+                2,
+                7
+            ],
+            "legIntPurposes": [
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://armis.tech/en/armis-personal-data-privacy-policy/"
+        },
+        "167": {
+            "id": 167,
+            "name": "Audiens S.r.l.",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://www.audiens.com/privacy"
+        },
+        "240": {
+            "id": 240,
+            "name": "7Hops.com Inc. (ZergNet)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                5,
+                6,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://zergnet.com/privacy"
+        },
+        "235": {
+            "id": 235,
+            "name": "Bucksense Inc",
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.bucksense.com/platform-privacy-policy/"
+        },
+        "185": {
+            "id": 185,
+            "name": "Bidtellect, Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8
+            ],
+            "legIntPurposes": [
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.bidtellect.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "211": {
+            "id": 211,
+            "name": "AdTheorent, Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://adtheorent.com/privacy-policy"
+        },
+        "273": {
+            "id": 273,
+            "name": "Bannerflow AB",
+            "purposes": [
+                1,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.bannerflow.com/privacy "
+        },
+        "104": {
+            "id": 104,
+            "name": "Sonobi, Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://sonobi.com/privacy-policy/"
+        },
+        "162": {
+            "id": 162,
+            "name": "Unruly Group Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://unruly.co/privacy/"
+        },
+        "249": {
+            "id": 249,
+            "name": "Spolecznosci Sp. z o.o. Sp. k.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.spolecznosci.pl/polityka-prywatnosci"
+        },
+        "160": {
+            "id": 160,
+            "name": "Netsprint SA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://netsprint.eu/privacy.html",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "279": {
+            "id": 279,
+            "name": "Mirando GmbH &amp; Co KG",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://wwwmirando.de/datenschutz/"
+        },
+        "255": {
+            "id": 255,
+            "name": "Onnetwork Sp. z o.o.",
+            "purposes": [
+                1,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.onnetwork.tv/pp_services.php"
+        },
+        "203": {
+            "id": 203,
+            "name": "Revcontent, LLC",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://intercom.help/revcontent2/en/articles/2290675-revcontent-s-privacy-policy"
+        },
+        "274": {
+            "id": 274,
+            "name": "Golden Bees",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.goldenbees.fr/en/privacy-charter/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "280": {
+            "id": 280,
+            "name": "Spot.IM LTD",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.spot.im/privacy/"
+        },
+        "239": {
+            "id": 239,
+            "name": "Triton Digital Canada Inc.",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.tritondigital.com/privacy-policies"
+        },
+        "177": {
+            "id": 177,
+            "name": "plista GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.plista.com/about/privacy/"
+        },
+        "150": {
+            "id": 150,
+            "name": "Inskin Media LTD",
+            "purposes": [
+                1,
+                3,
+                4,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.inskinmedia.com/privacy-policy.html"
+        },
+        "252": {
+            "id": 252,
+            "name": "Jaduda GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.jadudamobile.com/datenschutzerklaerung/"
+        },
+        "248": {
+            "id": 248,
+            "name": "Converge-Digital",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://converge-digital.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "161": {
+            "id": 161,
+            "name": "Smadex SL",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://smadex.com/end-user-privacy-policy/"
+        },
+        "285": {
+            "id": 285,
+            "name": "Comcast International France SAS",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.freewheel.com/privacy-policy"
+        },
+        "228": {
+            "id": 228,
+            "name": "McCann Discipline LTD",
+            "purposes": [
+                1,
+                2,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                5,
+                6,
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.primis.tech/privacy-policy/"
+        },
+        "299": {
+            "id": 299,
+            "name": "AdClear GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adclear.de/datenschutzerklaerung/"
+        },
+        "277": {
+            "id": 277,
+            "name": "Codewise VL Sp. z o.o. Sp. k",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://voluumdsp.com/end-user-privacy-policy/"
+        },
+        "259": {
+            "id": 259,
+            "name": "ADYOULIKE SA",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adyoulike.com/privacy_policy.php"
+        },
+        "289": {
+            "id": 289,
+            "name": "mobalo GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.mobalo.com/en/privacy/"
+        },
+        "272": {
+            "id": 272,
+            "name": "A.Mob",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.we-are-adot.com/privacy-policy/"
+        },
+        "253": {
+            "id": 253,
+            "name": "Improve Digital BV",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.improvedigital.com/platform-privacy-policy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "304": {
+            "id": 304,
+            "name": "On Device Research Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://s.on-device.com/privacyPolicy"
+        },
+        "314": {
+            "id": 314,
+            "name": "Keymantics",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.keymantics.com/assets/privacy-policy.pdf"
+        },
+        "317": {
+            "id": 317,
+            "name": "mainADV Srl",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.mainad.com/privacy-policy/"
+        },
+        "278": {
+            "id": 278,
+            "name": "Integral Ad Science, Inc.",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://integralads.com/privacy-policy/"
+        },
+        "315": {
+            "id": 315,
+            "name": "Celtra, Inc.",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.celtra.com/privacy-policy/"
+        },
+        "165": {
+            "id": 165,
+            "name": "SpotX, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.spotx.tv/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "47": {
+            "id": 47,
+            "name": "ADMAN - Phaistos Networks, S.A.",
+            "purposes": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.adman.gr/privacy"
+        },
+        "134": {
+            "id": 134,
+            "name": "SMARTSTREAM.TV GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.smartstream.tv/en/productprivacy",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "325": {
+            "id": 325,
+            "name": "Knorex",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.knorex.com/privacy"
+        },
+        "316": {
+            "id": 316,
+            "name": "Gamned",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.gamned.com/privacy-policy/"
+        },
+        "318": {
+            "id": 318,
+            "name": "Accorp Sp. z o.o.",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.instytut-pollster.pl/privacy-policy/"
+        },
+        "199": {
+            "id": 199,
+            "name": "ADUX",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                6,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adux.com/donnees-personelles/"
+        },
+        "294": {
+            "id": 294,
+            "name": "Jivox Corporation",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.jivox.com/privacy",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "143": {
+            "id": 143,
+            "name": "Connatix Native Exchange Inc.",
+            "purposes": [
+                1,
+                2,
+                4,
+                6,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://connatix.com/privacy-policy/"
+        },
+        "297": {
+            "id": 297,
+            "name": "Polar Mobile Group Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://privacy.polar.me"
+        },
+        "319": {
+            "id": 319,
+            "name": "Clipcentric, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://clipcentric.com/privacy.bhtml"
+        },
+        "290": {
+            "id": 290,
+            "name": "Readpeak Oy",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://readpeak.com/privacy-policy/"
+        },
+        "323": {
+            "id": 323,
+            "name": "DAZN Media Services Limited",
+            "purposes": [
+                1,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [
+                2,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.goal.com/en-gb/legal/privacy-policy"
+        },
+        "119": {
+            "id": 119,
+            "name": "Fusio by S4M",
+            "purposes": [
+                1,
+                3,
+                4,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                4,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.s4m.io/privacy-policy/"
+        },
+        "302": {
+            "id": 302,
+            "name": "Mobile Professionals BV",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                5,
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://mobpro.com/privacy.html"
+        },
+        "212": {
+            "id": 212,
+            "name": "usemax advertisement (Emego GmbH)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.usemax.de/?l=privacy"
+        },
+        "264": {
+            "id": 264,
+            "name": "Adobe Advertising Cloud",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                10
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adobe.com/privacy/experience-cloud.html"
+        },
+        "44": {
+            "id": 44,
+            "name": "The ADEX GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://theadex.com/privacy-opt-out/"
+        },
+        "282": {
+            "id": 282,
+            "name": "Welect GmbH",
+            "purposes": [
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.welect.de/datenschutz"
+        },
+        "238": {
+            "id": 238,
+            "name": "StackAdapt",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.stackadapt.com/privacy"
+        },
+        "284": {
+            "id": 284,
+            "name": "WEBORAMA",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://weborama.com/privacy_en/"
+        },
+        "301": {
+            "id": 301,
+            "name": "zeotap GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://zeotap.com/privacy_policy"
+        },
+        "275": {
+            "id": 275,
+            "name": "TabMo SAS",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://static.tabmo.io.s3.amazonaws.com/privacy-policy/index.html"
+        },
+        "310": {
+            "id": 310,
+            "name": "Adevinta Spain S.L.U.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adevinta.com/about/privacy/"
+        },
+        "139": {
+            "id": 139,
+            "name": "Permodo GmbH",
+            "purposes": [
+                1,
+                2,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://permodo.com/de/privacy.html",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "262": {
+            "id": 262,
+            "name": "Fyber ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.fyber.com/legal/privacy-policy/"
+        },
+        "331": {
+            "id": 331,
+            "name": "ad6media",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.ad6media.fr/privacy"
+        },
+        "345": {
+            "id": 345,
+            "name": "The Kantar Group Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://www.kantar.com/cookies-policies"
+        },
+        "270": {
+            "id": 270,
+            "name": "Marfeel Solutions, SL",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.marfeel.com/privacy-policy/"
+        },
+        "333": {
+            "id": 333,
+            "name": "InMobi Pte Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                9
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.inmobi.com/privacy-policy-for-eea"
+        },
+        "202": {
+            "id": 202,
+            "name": "Telaria, Inc",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://telaria.com/privacy-policy/"
+        },
+        "328": {
+            "id": 328,
+            "name": "Gemius SA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.gemius.com/cookie-policy.html"
+        },
+        "281": {
+            "id": 281,
+            "name": "Wizaly",
+            "purposes": [
+                1,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.wizaly.com/terms-of-use#privacy-policy"
+        },
+        "354": {
+            "id": 354,
+            "name": "Apester Ltd",
+            "purposes": [
+                2,
+                4
+            ],
+            "legIntPurposes": [
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://apester.com/privacy-policy/"
+        },
+        "359": {
+            "id": 359,
+            "name": "AerServ LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                9
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.inmobi.com/privacy-policy-for-eea"
+        },
+        "265": {
+            "id": 265,
+            "name": "Instinctive, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://instinctive.io/privacy"
+        },
+        "303": {
+            "id": 303,
+            "name": "Orion Semantics",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://static.orion-semantics.com/privacy.html"
+        },
+        "83": {
+            "id": 83,
+            "name": "Visarity Technologies GmbH",
+            "purposes": [
+                2,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://primo.design/docs/PrivacyPolicyPrimo.html"
+        },
+        "343": {
+            "id": 343,
+            "name": "DIGITEKA Technologies",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ultimedia.com/POLICY.html"
+        },
+        "231": {
+            "id": 231,
+            "name": "AcuityAds Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                3,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://privacy.acuityads.com/corporate-privacy-policy.html",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "216": {
+            "id": 216,
+            "name": "Mindlytix SAS",
+            "purposes": [
+                1,
+                2,
+                3,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://mindlytix.com/privacy/"
+        },
+        "360": {
+            "id": 360,
+            "name": "Permutive Technologies, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                5,
+                7,
+                8,
+                9
+            ],
+            "flexiblePurposes": [
+                3,
+                5,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://permutive.com/privacy/"
+        },
+        "361": {
+            "id": 361,
+            "name": "Permutive Limited",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                5,
+                7,
+                8,
+                9
+            ],
+            "flexiblePurposes": [
+                3,
+                5,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://permutive.com/privacy/"
+        },
+        "311": {
+            "id": 311,
+            "name": "Mobfox US LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.mobfox.com/privacy-policy/"
+        },
+        "358": {
+            "id": 358,
+            "name": "MGID Inc.",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.mgid.com/privacy-policy"
+        },
+        "152": {
+            "id": 152,
+            "name": "Meetrics GmbH",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.meetrics.com/en/data-privacy/"
+        },
+        "251": {
+            "id": 251,
+            "name": "Yieldlove GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.yieldlove.com/cookie-policy"
+        },
+        "371": {
+            "id": 371,
+            "name": "Seeding Alliance GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://seeding-alliance.de/datenschutz/"
+        },
+        "347": {
+            "id": 347,
+            "name": "Ezoic Inc.",
+            "purposes": [
+                1,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [
+                6,
+                10
+            ],
+            "flexiblePurposes": [
+                6,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ezoic.com/terms/"
+        },
+        "218": {
+            "id": 218,
+            "name": "Bigabid Media ltd",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.bigabid.com/privacy-policy"
+        },
+        "350": {
+            "id": 350,
+            "name": "Free Stream Media Corp. dba Samba TV",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://samba.tv/legal/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "351": {
+            "id": 351,
+            "name": "Samba TV UK Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://samba.tv/legal/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "380": {
+            "id": 380,
+            "name": "Vidoomy Media SL",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://vidoomy.com/privacy-policy.html"
+        },
+        "184": {
+            "id": 184,
+            "name": "mediarithmics SAS",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.mediarithmics.com/en-us/content/privacy-policy"
+        },
+        "368": {
+            "id": 368,
+            "name": "VECTAURY",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.vectaury.io/en/personal-data"
+        },
+        "373": {
+            "id": 373,
+            "name": "Nielsen Marketing Cloud",
+            "purposes": [
+                1,
+                3,
+                5
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.nielsen.com/us/en/privacy-statement/exelate-privacy-policy.html"
+        },
+        "388": {
+            "id": 388,
+            "name": "numberly",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://numberly.com/en/privacy/"
+        },
+        "250": {
+            "id": 250,
+            "name": "Qriously Ltd",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.brandwatch.com/legal/qriously-privacy-notice/"
+        },
+        "223": {
+            "id": 223,
+            "name": "Audience Trading Platform Ltd.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://atp.io/privacy-policy"
+        },
+        "384": {
+            "id": 384,
+            "name": "Pixalate, Inc.",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://pixalate.com/privacypolicy/"
+        },
+        "387": {
+            "id": 387,
+            "name": "Triapodi Ltd.",
+            "purposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://appreciate.mobi/page.html#/end-user-privacy-policy"
+        },
+        "312": {
+            "id": 312,
+            "name": "Exactag GmbH",
+            "purposes": [
+                1,
+                3,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                3,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.exactag.com/en/data-privacy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "178": {
+            "id": 178,
+            "name": "Hybrid Theory",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://hybridtheory.com/privacy-policy/"
+        },
+        "377": {
+            "id": 377,
+            "name": "AddApptr GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.addapptr.com/data-privacy"
+        },
+        "382": {
+            "id": 382,
+            "name": "The Reach Group GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://trg.de/en/privacy-statement/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "206": {
+            "id": 206,
+            "name": "Hybrid Adtech GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://hybrid.ai/data_protection_policy"
+        },
+        "385": {
+            "id": 385,
+            "name": "Oracle Data Cloud",
+            "purposes": [
+                1,
+                3,
+                5,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.oracle.com/legal/privacy/marketing-cloud-data-cloud-privacy-policy.html"
+        },
+        "242": {
+            "id": 242,
+            "name": "twiago GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.twiago.com/datenschutz/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "402": {
+            "id": 402,
+            "name": "Effiliation",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://inter.effiliation.com/politique-confidentialite.html"
+        },
+        "413": {
+            "id": 413,
+            "name": "Eulerian Technologies",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.eulerian.com/en/privacy/"
+        },
+        "415": {
+            "id": 415,
+            "name": "Seenthis AB",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://seenthis.co/privacy-notice-2018-04-18.pdf"
+        },
+        "263": {
+            "id": 263,
+            "name": "Nativo, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.nativo.com/interest-based-ads"
+        },
+        "329": {
+            "id": 329,
+            "name": "Browsi Mobile Ltd",
+            "purposes": [
+                1,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://gobrowsi.com/browsi-privacy-policy/"
+        },
+        "337": {
+            "id": 337,
+            "name": "SheMedia, LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.shemedia.com/ad-services-privacy-policy"
+        },
+        "422": {
+            "id": 422,
+            "name": "Brand Metrics Sweden AB",
+            "purposes": [
+                1,
+                6,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://collector.brandmetrics.com/brandmetrics_privacypolicy.pdf"
+        },
+        "394": {
+            "id": 394,
+            "name": "AudienceProject Aps",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://privacy.audienceproject.com"
+        },
+        "243": {
+            "id": 243,
+            "name": "Cloud Technologies S.A.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.cloudtechnologies.pl/en/internet-advertising-privacy-policy"
+        },
+        "416": {
+            "id": 416,
+            "name": "Commanders Act",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.commandersact.com/en/privacy/"
+        },
+        "434": {
+            "id": 434,
+            "name": "DynAdmic",
+            "purposes": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "legIntPurposes": [
+                3,
+                6,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://eu.dynadmic.com/privacy-policy/"
+        },
+        "435": {
+            "id": 435,
+            "name": "SINGLESPOT SAS ",
+            "purposes": [
+                1,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.singlespot.com/privacy_policy?locale=fr"
+        },
+        "409": {
+            "id": 409,
+            "name": "Arrivalist Co.",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.arrivalist.com/privacy"
+        },
+        "436": {
+            "id": 436,
+            "name": "INVIBES GROUP",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.invibes.com/terms"
+        },
+        "418": {
+            "id": 418,
+            "name": "PROXISTORE",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.proxistore.com/common/en/cgv"
+        },
+        "429": {
+            "id": 429,
+            "name": "Signals",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://signalsdata.com/platform-cookie-policy/"
+        },
+        "374": {
+            "id": 374,
+            "name": "Bmind a Sales Maker Company, S.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.bmind.es/legal-notice/"
+        },
+        "438": {
+            "id": 438,
+            "name": "INVIDI technologies AB",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.invidi.com/wp-content/uploads/2020/02/ad-tech-services-privacy-policy.pdf"
+        },
+        "450": {
+            "id": 450,
+            "name": "Neodata Group srl",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.neodatagroup.com/en/security-policy",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "444": {
+            "id": 444,
+            "name": "Playbuzz Ltd (aka EX.CO)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                5,
+                6
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://ex.co/privacy-policy/"
+        },
+        "412": {
+            "id": 412,
+            "name": "Cxense ASA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.cxense.com/about-us/privacy-policy"
+        },
+        "455": {
+            "id": 455,
+            "name": "GDMServices, Inc. d/b/a FiksuDSP",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                10
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://fiksu.com/privacy-policy/"
+        },
+        "423": {
+            "id": 423,
+            "name": "travel audience GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://travelaudience.com/product-privacy-policy/"
+        },
+        "381": {
+            "id": 381,
+            "name": "Solocal",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://frontend.adhslx.com/privacy.html?"
+        },
+        "365": {
+            "id": 365,
+            "name": "Forensiq LLC",
+            "purposes": [],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://impact.com/privacy-policy/"
+        },
+        "447": {
+            "id": 447,
+            "name": "Adludio Ltd",
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.adludio.com/privacy-policy/"
+        },
+        "410": {
+            "id": 410,
+            "name": "Adtelligent Inc.",
+            "purposes": [
+                1,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adtelligent.com/privacy-policy/"
+        },
+        "137": {
+            "id": 137,
+            "name": "Str\u00f6er SSP GmbH (DSP)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.stroeer.de/fileadmin/de/Konvergenz_und_Konzepte/Daten_und_Technologien/Stroeer_SSP/Downloads/Datenschutz_Stroeer_SSP.pdf"
+        },
+        "466": {
+            "id": 466,
+            "name": "TACTIC\u2122 Real-Time Marketing AS",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://tacticrealtime.com/privacy/"
+        },
+        "431": {
+            "id": 431,
+            "name": "White Ops, Inc.",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://www.whiteops.com/privacy"
+        },
+        "336": {
+            "id": 336,
+            "name": "Telecoming S.A.",
+            "purposes": [
+                2,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                9
+            ],
+            "flexiblePurposes": [
+                2,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.telecoming.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "440": {
+            "id": 440,
+            "name": "DEFINE MEDIA GMBH",
+            "purposes": [
+                1,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.definemedia.de/datenschutz-conative/"
+        },
+        "375": {
+            "id": 375,
+            "name": "Affle International",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://affle.com/privacy-policy "
+        },
+        "475": {
+            "id": 475,
+            "name": "TAPTAP Digital SL",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+            ],
+            "legIntPurposes": [
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.taptapnetworks.com/privacy_policy/"
+        },
+        "448": {
+            "id": 448,
+            "name": "Targetspot Belgium SPRL",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://marketing.targetspot.com/Targetspot/Legal/TargetSpot%20Privacy%20Policy%20-%20June%202018.pdf",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "428": {
+            "id": 428,
+            "name": "Internet BillBoard a.s.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.ibillboard.com/en/privacy-information/"
+        },
+        "486": {
+            "id": 486,
+            "name": "Madington",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://delivered-by-madington.com/dat-privacy-policy/"
+        },
+        "468": {
+            "id": 468,
+            "name": "NeuStar, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.home.neustar/privacy"
+        },
+        "293": {
+            "id": 293,
+            "name": "SpringServe, LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://springserve.com/privacy-policy/"
+        },
+        "484": {
+            "id": 484,
+            "name": "STRIATUM SAS",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://adledge.com/data-privacy/"
+        },
+        "493": {
+            "id": 493,
+            "name": "Carbon (AI) Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://carbonrmp.com/privacy.html"
+        },
+        "495": {
+            "id": 495,
+            "name": "Arcspire Limited",
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://public.arcspire.io/privacy.pdf",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "424": {
+            "id": 424,
+            "name": "KUPONA GmbH",
+            "purposes": [
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                4
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.kupona.de/dsgvo/"
+        },
+        "408": {
+            "id": 408,
+            "name": "Fidelity Media",
+            "purposes": [
+                1,
+                2,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://fidelity-media.com/privacy-policy/"
+        },
+        "467": {
+            "id": 467,
+            "name": "Haensel AMS GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://haensel-ams.com/data-privacy/"
+        },
+        "488": {
+            "id": 488,
+            "name": "Opinary GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://opinary.com/privacy-policy/"
+        },
+        "490": {
+            "id": 490,
+            "name": "PLAYGROUND XYZ EMEA LTD",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://playground.xyz/privacy"
+        },
+        "491": {
+            "id": 491,
+            "name": "Triboo Data Analytics",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.shinystat.com/it/informativa_privacy_generale.html"
+        },
+        "502": {
+            "id": 502,
+            "name": "NEXD",
+            "purposes": [
+                1,
+                7,
+                10
+            ],
+            "legIntPurposes": [
+                9
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://nexd.com/privacy-policy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "508": {
+            "id": 508,
+            "name": "Lucid Holdings, LLC",
+            "purposes": [
+                1,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "luc.id/privacy-policy"
+        },
+        "512": {
+            "id": 512,
+            "name": "PubNative GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://pubnative.net/privacy-notice/"
+        },
+        "516": {
+            "id": 516,
+            "name": "Pexi B.V.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://pexi.nl/privacy-policy/"
+        },
+        "507": {
+            "id": 507,
+            "name": "AdsWizz Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.adswizz.com/our-privacy-policy/"
+        },
+        "482": {
+            "id": 482,
+            "name": "UberMedia, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://ubermedia.com/summary-of-privacy-policy/"
+        },
+        "505": {
+            "id": 505,
+            "name": "Shopalyst Inc",
+            "purposes": [
+                1,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.shortlyst.com/eu/privacy_terms.html"
+        },
+        "517": {
+            "id": 517,
+            "name": "SunMedia ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.sunmedia.tv/en/cookies"
+        },
+        "511": {
+            "id": 511,
+            "name": "Admixer EU GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                9
+            ],
+            "legIntPurposes": [
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://admixer.com/privacy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "479": {
+            "id": 479,
+            "name": "INFINIA MOBILE S.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://www.infiniamobile.com/privacy_policy"
+        },
+        "509": {
+            "id": 509,
+            "name": "ATG Ad Tech Group GmbH",
+            "purposes": [
+                2,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://ad-tech-group.com/privacy-policy/"
+        },
+        "521": {
+            "id": 521,
+            "name": "netzeffekt GmbH",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.netzeffekt.de/en/imprint"
+        },
+        "524": {
+            "id": 524,
+            "name": "The Ozone Project Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://ozoneproject.com/privacy-policy"
+        },
+        "528": {
+            "id": 528,
+            "name": "Kayzen",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://kayzen.io/data-privacy-policy"
+        },
+        "527": {
+            "id": 527,
+            "name": "Jampp LTD",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://jampp.com/privacy.html"
+        },
+        "535": {
+            "id": 535,
+            "name": "INNITY",
+            "purposes": [
+                1,
+                2,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.innity.com/privacy-policy.php"
+        },
+        "530": {
+            "id": 530,
+            "name": "Near Pte Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://near.co/privacy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "539": {
+            "id": 539,
+            "name": "AdDefend GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.addefend.com/en/privacy-policy/"
+        },
+        "501": {
+            "id": 501,
+            "name": "Alliance Gravity Data Media",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.alliancegravity.com/politiquedeprotectiondesdonneespersonnelles"
+        },
+        "531": {
+            "id": 531,
+            "name": "Smartclip Hispania SL",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://rgpd-smartclip.com/"
+        },
+        "536": {
+            "id": 536,
+            "name": "GlobalWebIndex",
+            "purposes": [
+                1,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://legal.trendstream.net/non-panellist_privacy_policy"
+        },
+        "544": {
+            "id": 544,
+            "name": "Kochava Inc.",
+            "purposes": [],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.kochava.com/support-privacy/"
+        },
+        "543": {
+            "id": 543,
+            "name": "PaperG, Inc. dba Thunder Industries",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.makethunder.com/privacy"
+        },
+        "546": {
+            "id": 546,
+            "name": "Smart Traffik",
+            "purposes": [
+                1,
+                8
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://okube-attribution.com/politique-de-confidentialite/"
+        },
+        "545": {
+            "id": 545,
+            "name": "Reignn Platform Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "http://reignn.com/user-privacy-policy"
+        },
+        "439": {
+            "id": 439,
+            "name": "Bit Q Holdings Limited",
+            "purposes": [
+                1,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.rippll.com/privacy"
+        },
+        "553": {
+            "id": 553,
+            "name": "Adhese",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adhese.com/privacy-and-cookie-policy"
+        },
+        "556": {
+            "id": 556,
+            "name": "adhood.com",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://v3.adhood.com/en/site/politikavekurallar/gizlilik.php?lang=en"
+        },
+        "550": {
+            "id": 550,
+            "name": "Happydemics",
+            "purposes": [
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.iubenda.com/privacy-policy/69056167/full-legal"
+        },
+        "554": {
+            "id": 554,
+            "name": "RMSi Radio Marketing Service interactive GmbH",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.rms.de/datenschutz/"
+        },
+        "498": {
+            "id": 498,
+            "name": "Mediakeys Platform",
+            "purposes": [
+                1,
+                6,
+                10
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://drbanner.com/privacypolicy_en/"
+        },
+        "565": {
+            "id": 565,
+            "name": "Adobe Audience Manager",
+            "purposes": [
+                1,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adobe.com/privacy/policy.html"
+        },
+        "571": {
+            "id": 571,
+            "name": "ViewPay",
+            "purposes": [
+                1,
+                2,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://viewpay.tv/mentions-legales/"
+        },
+        "568": {
+            "id": 568,
+            "name": "Jointag S.r.l.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.jointag.com/privacy/kariboo/publisher/third/"
+        },
+        "570": {
+            "id": 570,
+            "name": "Czech Publisher Exchange z.s.p.o.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.cpex.cz/pro-uzivatele/ochrana-soukromi/"
+        },
+        "559": {
+            "id": 559,
+            "name": "Otto (GmbH &amp; Co KG)",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.otto.de/shoppages/service/datenschutz"
+        },
+        "569": {
+            "id": 569,
+            "name": "Kairos Fire",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.kairosfire.com/privacy"
+        },
+        "577": {
+            "id": 577,
+            "name": "Neustar on behalf of The Procter & Gamble Company",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                5,
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.pg.com/privacy/english/privacy_statement.shtml"
+        },
+        "590": {
+            "id": 590,
+            "name": "Sourcepoint Technologies, Inc.",
+            "purposes": [],
+            "legIntPurposes": [
+                6,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.sourcepoint.com/privacy-policy"
+        },
+        "587": {
+            "id": 587,
+            "name": "Localsensor B.V.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.localsensor.com/privacy.html"
+        },
+        "580": {
+            "id": 580,
+            "name": "Goldbach Group AG",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://goldbach.com/ch/de/datenschutz"
+        },
+        "593": {
+            "id": 593,
+            "name": "Programatica de publicidad S.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://datmean.com/politica-privacidad/"
+        },
+        "574": {
+            "id": 574,
+            "name": "Realeyes OU",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://realview.realeyesit.com/privacy"
+        },
+        "598": {
+            "id": 598,
+            "name": "audio content &amp; control GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.audio-cc.com/audiocc_privacy_policy.pdf"
+        },
+        "596": {
+            "id": 596,
+            "name": "InsurAds Technologies SA.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.insurads.com/privacy.html"
+        },
+        "549": {
+            "id": 549,
+            "name": "Bandsintown Amplified LLC",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://corp.bandsintown.com/privacy"
+        },
+        "584": {
+            "id": 584,
+            "name": "Dynamic 1001 GmbH",
+            "purposes": [
+                1,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://dynamic-tracking.com/Datenschutz.aspx"
+        },
+        "601": {
+            "id": 601,
+            "name": "WebAds B.V",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://privacy.webads.eu/"
+        },
+        "599": {
+            "id": 599,
+            "name": "Maximus Live LLC",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://maximusx.com/privacy-policy/"
+        },
+        "606": {
+            "id": 606,
+            "name": "Impactify ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://impactify.io/privacy-policy/"
+        },
+        "602": {
+            "id": 602,
+            "name": "Online Solution Int Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adsafety.net/privacy.html",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "612": {
+            "id": 612,
+            "name": "Adnami Aps",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "www.adnami.io/privacy"
+        },
+        "591": {
+            "id": 591,
+            "name": "Consumable, Inc.",
+            "purposes": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://consumable.com/privacy-policy.html"
+        },
+        "614": {
+            "id": 614,
+            "name": "Market Resource Partners LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://www.mrpfd.com/privacy-policy/"
+        },
+        "615": {
+            "id": 615,
+            "name": "Adsolutions BV",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adsolutions.com/privacy-policy/"
+        },
+        "607": {
+            "id": 607,
+            "name": "ucfunnel Co., Ltd.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ucfunnel.com/privacy-policy"
+        },
+        "609": {
+            "id": 609,
+            "name": "Predicio",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://www.predic.io/privacy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "617": {
+            "id": 617,
+            "name": "Onfocus (Adagio)",
+            "purposes": [
+                1,
+                2,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adagio.io/privacy"
+        },
+        "620": {
+            "id": 620,
+            "name": "Blue",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.getblue.io/privacy/"
+        },
+        "610": {
+            "id": 610,
+            "name": "Azerion Holding B.V.",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                5,
+                6
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://azerion.com/business/privacy.html",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "621": {
+            "id": 621,
+            "name": "Seznam.cz, a.s.",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.seznam.cz/ochranaudaju"
+        },
+        "624": {
+            "id": 624,
+            "name": "Norstat AS",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.norstatpanel.com/en/data-protection"
+        },
+        "95": {
+            "id": 95,
+            "name": "Lotame Solutions, inc",
+            "purposes": [
+                1,
+                3,
+                5
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.lotame.com/about-lotame/privacy/lotame-corporate-websites-privacy-policy/"
+        },
+        "618": {
+            "id": 618,
+            "name": "BEINTOO SPA",
+            "purposes": [
+                1,
+                2,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.beintoo.com/privacy-cookie-policy/"
+        },
+        "625": {
+            "id": 625,
+            "name": "BILENDI SA",
+            "purposes": [
+                1,
+                6,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.maximiles.com/privacy-policy"
+        },
+        "628": {
+            "id": 628,
+            "name": ": Tappx",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.tappx.com/en/privacy-policy/"
+        },
+        "630": {
+            "id": 630,
+            "name": "Contact Impact GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://contactimpact.de/privacy"
+        },
+        "626": {
+            "id": 626,
+            "name": "Hivestack Inc.",
+            "purposes": [
+                1,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://hivestack.com/privacy-policy"
+        },
+        "631": {
+            "id": 631,
+            "name": "Relay42 Netherlands B.V.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://relay42.com/privacy"
+        },
+        "638": {
+            "id": 638,
+            "name": "Passendo Aps",
+            "purposes": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://passendo.com/users-privacy-policy"
+        },
+        "644": {
+            "id": 644,
+            "name": "Gamoshi LTD",
+            "purposes": [
+                2,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.gamoshi.com/privacy-policy"
+        },
+        "639": {
+            "id": 639,
+            "name": "Smile Wanted Group",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://www.smilewanted.com/privacy.php"
+        },
+        "645": {
+            "id": 645,
+            "name": "Noster Finance S.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.finect.com/terminos-legales/politica-de-cookies"
+        },
+        "653": {
+            "id": 653,
+            "name": "Smartme Analytics",
+            "purposes": [
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://smartmeapp.com/info/smartme/aviso_legal.php",
+            "deletedDate": "2020-07-03T00:00:00Z"
+        },
+        "613": {
+            "id": 613,
+            "name": "Adserve.zone / Artworx AS",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://adserve.zone/adserveprivacypolicy.html"
+        },
+        "573": {
+            "id": 573,
+            "name": "Dailymotion SA",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.dailymotion.com/legal/privacy",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "652": {
+            "id": 652,
+            "name": "Skaze",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.skaze.fr/rgpd/"
+        },
+        "646": {
+            "id": 646,
+            "name": "Notify",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://notify-group.com/en/mentions-legales/"
+        },
+        "648": {
+            "id": 648,
+            "name": "TrueData Solutions, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.truedata.co/privacy-policy/"
+        },
+        "647": {
+            "id": 647,
+            "name": "Axel Springer Teaser Ad GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adup-tech.com/privacy"
+        },
+        "659": {
+            "id": 659,
+            "name": "Research and Analysis of Media in Sweden AB",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                9
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www2.rampanel.com/privacy-policy/"
+        },
+        "656": {
+            "id": 656,
+            "name": "Think Clever Media",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.contentignite.com/privacy-policy/"
+        },
+        "657": {
+            "id": 657,
+            "name": "GP One GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.gsi-one.org/de/privacy-policy.html"
+        },
+        "655": {
+            "id": 655,
+            "name": "Sportradar AG",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.sportradar.com/about-us/privacy/"
+        },
+        "662": {
+            "id": 662,
+            "name": "SoundCast",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://soundcast.fm/en/data-privacy"
+        },
+        "665": {
+            "id": 665,
+            "name": "Digital East GmbH",
+            "purposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.digitaleast.mobi/en/legal/privacy-policy/"
+        },
+        "650": {
+            "id": 650,
+            "name": "Telefonica Investigaci\u00f3n y Desarrollo S.A.U",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://www.cognitivemarketing.tid.es/"
+        },
+        "666": {
+            "id": 666,
+            "name": "BeOp",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://beop.io/privacy"
+        },
+        "663": {
+            "id": 663,
+            "name": "Mobsuccess",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.mobsuccess.com/en/privacy"
+        },
+        "658": {
+            "id": 658,
+            "name": "BLIINK SAS",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://bliink.io/privacy-policy"
+        },
+        "667": {
+            "id": 667,
+            "name": "Liftoff Mobile, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://liftoff.io/privacy-policy/"
+        },
+        "668": {
+            "id": 668,
+            "name": "WhatRocks Inc. ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.whatrocks.co/en/privacy-policy "
+        },
+        "674": {
+            "id": 674,
+            "name": "Duration Media, LLC.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.durationmedia.net/privacy-policy"
+        },
+        "675": {
+            "id": 675,
+            "name": "Instreamatic inc.",
+            "purposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://instreamatic.com/privacy-policy/"
+        },
+        "676": {
+            "id": 676,
+            "name": "BusinessClick",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.businessclick.com/documents/RegulaminProgramuBusinessClick-2019.pdf"
+        },
+        "672": {
+            "id": 672,
+            "name": "Cedato Technologies Ltd",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.cedato.com/privacy-policy/"
+        },
+        "664": {
+            "id": 664,
+            "name": "adMarketplace, Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.admarketplace.com/privacy-policy/"
+        },
+        "561": {
+            "id": 561,
+            "name": "AuDigent",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://audigent.com/platform-privacy-policy"
+        },
+        "682": {
+            "id": 682,
+            "name": "Radio Net Media Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.adtonos.com/service-privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "684": {
+            "id": 684,
+            "name": "Blue Billywig BV",
+            "purposes": [],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.bluebillywig.com/privacy-statement/"
+        },
+        "686": {
+            "id": 686,
+            "name": "The MediaGrid Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.themediagrid.com/privacy-policy/"
+        },
+        "685": {
+            "id": 685,
+            "name": "Arkeero",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://arkeero.com/privacy-2/"
+        },
+        "687": {
+            "id": 687,
+            "name": "MISSENA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://missena.com/confidentialite/"
+        },
+        "690": {
+            "id": 690,
+            "name": "Go.pl sp. z o.o.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://go.pl/polityka-prywatnosci/"
+        },
+        "691": {
+            "id": 691,
+            "name": "Lifesight Pte. Ltd.",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.lifesight.io/privacy-policy/"
+        },
+        "697": {
+            "id": 697,
+            "name": "ADWAYS SAS",
+            "purposes": [],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adways.com/confidentialite/?lang=en"
+        },
+        "699": {
+            "id": 699,
+            "name": "HyperTV Inc.",
+            "purposes": [
+                1,
+                2,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.hypertvx.com/privacy/"
+        },
+        "703": {
+            "id": 703,
+            "name": "MindTake Research GmbH",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.mindtake.com/en/reppublika-privacy-policy"
+        },
+        "706": {
+            "id": 706,
+            "name": "VRTCAL Markets Inc",
+            "purposes": [],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://vrtcal.com/docs/PrivacyPolicy-Advertising.pdf"
+        },
+        "681": {
+            "id": 681,
+            "name": "MyTraffic",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                9
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.mytraffic.io/en/privacy"
+        },
+        "649": {
+            "id": 649,
+            "name": "adality GmbH",
+            "purposes": [],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://adality.de/en/privacy/"
+        },
+        "711": {
+            "id": 711,
+            "name": "SITU8ED SA",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.situ8ed.com/privacy-policy/"
+        },
+        "712": {
+            "id": 712,
+            "name": "Inspired Mobile Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://byinspired.com/privacypolicy.pdf"
+        },
+        "688": {
+            "id": 688,
+            "name": "Effinity",
+            "purposes": [],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.effiliation.com/politique-de-confidentialite/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "702": {
+            "id": 702,
+            "name": "Kwanko",
+            "purposes": [
+                1,
+                2,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.kwanko.com/fr/rgpd/"
+        },
+        "714": {
+            "id": 714,
+            "name": "Survata Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                7,
+                9
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.survata.com/respondent-privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "713": {
+            "id": 713,
+            "name": "Dataseat Ltd",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://dataseat.com/privacy-policy"
+        },
+        "716": {
+            "id": 716,
+            "name": "OnAudience Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.onaudience.com/internet-advertising-privacy-policy"
+        },
+        "708": {
+            "id": 708,
+            "name": "Dugout Limited ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://dugout.com/privacy-policy"
+        },
+        "694": {
+            "id": 694,
+            "name": "Snapupp Technologies SL",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.enterprise.noddus.com/privacy-policy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "683": {
+            "id": 683,
+            "name": "Cookie Market LTD",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "http://cookie.market/privacyPolicy.php"
+        },
+        "720": {
+            "id": 720,
+            "name": "AAX LLC",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://aax.media/privacy/",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "678": {
+            "id": 678,
+            "name": "Axonix LTD",
+            "purposes": [
+                2
+            ],
+            "legIntPurposes": [
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://axonix.com/privacy-cookie-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "719": {
+            "id": 719,
+            "name": "Online Advertising Network Sp. z o.o.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.oan.pl/en/privacy-policy"
+        },
+        "707": {
+            "id": 707,
+            "name": "Dentsu Aegis Network Italia SpA",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.dentsuaegisnetwork.com/it/it/policies/info-cookie"
+        },
+        "721": {
+            "id": 721,
+            "name": "Beaconspark Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7
+            ],
+            "legIntPurposes": [
+                6,
+                8
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.engageya.com/privacy"
+        },
+        "728": {
+            "id": 728,
+            "name": "Appier PTE Ltd",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.appier.com/privacy-policy/"
+        },
+        "729": {
+            "id": 729,
+            "name": "Cavai AS & UK ",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                8
+            ],
+            "flexiblePurposes": [
+                7,
+                8
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://cav.ai/privacy-policy/"
+        },
+        "730": {
+            "id": 730,
+            "name": "INFOnline GmbH",
+            "purposes": [],
+            "legIntPurposes": [
+                8
+            ],
+            "flexiblePurposes": [
+                8
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.infonline.de/en/privacy-policy/"
+        },
+        "722": {
+            "id": 722,
+            "name": "agof - daily campaign facts",
+            "purposes": [
+                1,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.agof.de/datenschutz/"
+        },
+        "723": {
+            "id": 723,
+            "name": "Adzymic Pte Ltd",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.adzymic.co/privacy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "725": {
+            "id": 725,
+            "name": "Pubfinity LLC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://pubfinity.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "733": {
+            "id": 733,
+            "name": "Anzu Virtual Reality LTD",
+            "purposes": [
+                1,
+                2,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://anzu.io/privacy/"
+        },
+        "737": {
+            "id": 737,
+            "name": "Monet Engine Inc",
+            "purposes": [
+                1,
+                2,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://appmonet.com/privacy-policy/"
+        },
+        "740": {
+            "id": 740,
+            "name": "6Sense Insights, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://6sense.com/privacy-policy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "744": {
+            "id": 744,
+            "name": "Vidazoo Ltd",
+            "purposes": [
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                3,
+                4
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://vidazoo.gitbook.io/vidazoo-legal/privacy-policy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "731": {
+            "id": 731,
+            "name": "GeistM Technologies LTD",
+            "purposes": [],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.geistm.com/privacy"
+        },
+        "741": {
+            "id": 741,
+            "name": "Brand Advance Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.wearebrandadvance.com/website-privacy-policy"
+        },
+        "735": {
+            "id": 735,
+            "name": "Deutsche Post AG",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.deutschepost.de/de/c/consentric/datenschutz.html"
+        },
+        "734": {
+            "id": 734,
+            "name": "Cint AB",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.cint.com/participant-privacy-notice"
+        },
+        "709": {
+            "id": 709,
+            "name": "NC Audience Exchange, LLC (NewsIQ)",
+            "purposes": [
+                1,
+                3,
+                4,
+                5
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.ncaudienceexchange.com/privacy/"
+        },
+        "739": {
+            "id": 739,
+            "name": "Blingby LLC",
+            "purposes": [
+                1,
+                8,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://blingby.com/privacy"
+        },
+        "727": {
+            "id": 727,
+            "name": "Pinpoll GmbH (Private Limited)",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.pinpoll.com/#data_protection_declaration"
+        },
+        "732": {
+            "id": 732,
+            "name": "Performax.cz, s.r.o.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://reg.tiscali.cz/privacy-policy"
+        },
+        "736": {
+            "id": 736,
+            "name": "BidMachine Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://explorestack.com/privacy-policy/"
+        },
+        "738": {
+            "id": 738,
+            "name": "adbility media GmbH",
+            "purposes": [
+                2,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.adbility-media.com/datenschutzerklaerung/"
+        },
+        "742": {
+            "id": 742,
+            "name": "Audiencerate LTD",
+            "purposes": [
+                1,
+                2,
+                3,
+                5,
+                6
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.audiencerate.com/privacy/"
+        },
+        "743": {
+            "id": 743,
+            "name": "MOVIads Sp. z o.o. Sp. k.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://moviads.pl/polityka-prywatnosci/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "745": {
+            "id": 745,
+            "name": "Justtag Sp. z o.o.",
+            "purposes": [
+                1,
+                3,
+                4,
+                9
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.justtag.com/pdf/PRIVACY_POLICY_Koalametrics_english.pdf"
+        },
+        "746": {
+            "id": 746,
+            "name": "Adxperience SAS",
+            "purposes": [
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adxperience.com/privacy-policy/"
+        },
+        "747": {
+            "id": 747,
+            "name": "Kairion GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://kairion.de/datenschutzbestimmungen/"
+        },
+        "748": {
+            "id": 748,
+            "name": "AUDIOMOB LTD",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.audiomob.io/privacy"
+        },
+        "749": {
+            "id": 749,
+            "name": "Good-Loop Ltd",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://doc.good-loop.com/policy/privacy-policy.html"
+        },
+        "750": {
+            "id": 750,
+            "name": "THE NEWCO S.R.L.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.thenewco.it/privacy_policy_servizi_prodotti.html"
+        },
+        "751": {
+            "id": 751,
+            "name": "Kiosked Ltd",
+            "purposes": [],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://kiosked.com/privacy-policy/"
+        },
+        "753": {
+            "id": 753,
+            "name": "ScaleMonk Inc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.scalemonk.com/privacy-policy/index.html"
+        },
+        "754": {
+            "id": 754,
+            "name": "DistroScale, Inc.",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.distroscale.com/privacy-policy/"
+        },
+        "757": {
+            "id": 757,
+            "name": "UAB Meazy",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                7,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://meazy.co/privacy-policy"
+        },
+        "758": {
+            "id": 758,
+            "name": "GfK Netherlands B.V.",
+            "purposes": [
+                1,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7,
+                8,
+                9
+            ],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://gfkpanel.nl/privacy"
+        },
+        "759": {
+            "id": 759,
+            "name": "RevJet",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.revjet.com/privacy",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "760": {
+            "id": 760,
+            "name": "VEXPRO TECHNOLOGIES LTD",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "https://onedash.com/privacy-policy.html"
+        },
+        "761": {
+            "id": 761,
+            "name": "Digiseg ApS",
+            "purposes": [
+                1,
+                3,
+                5,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://digiseg.io/privacy-center/"
+        },
+        "762": {
+            "id": 762,
+            "name": "Protected Media LTD",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.protected.media/privacy-policy/"
+        },
+        "764": {
+            "id": 764,
+            "name": "Lucidity",
+            "purposes": [
+                1,
+                2,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://golucidity.com/privacy-policy/"
+        },
+        "765": {
+            "id": 765,
+            "name": "Grabit Interactive Media Inc dba KERV Interctive",
+            "purposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://kervit.com/privacy-policy/"
+        },
+        "766": {
+            "id": 766,
+            "name": "ADCELL | Firstlead GmbH",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.adcell.de/agb#sector_6"
+        },
+        "767": {
+            "id": 767,
+            "name": "Clinch Labs LTD",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://clinch.co/pages/privacy.html"
+        },
+        "768": {
+            "id": 768,
+            "name": "Global Media & Entertainment Limited",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "http://global.com/privacy-policy/"
+        },
+        "769": {
+            "id": 769,
+            "name": "MEDIAMETRIE",
+            "purposes": [
+                1,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.mediametrie.fr/fr/gestion-des-cookies"
+        },
+        "770": {
+            "id": 770,
+            "name": "MARKETPERF CORP",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.marketperf.com/assets/images/app/marketperf/pdf/privacy-policy.pdf"
+        },
+        "771": {
+            "id": 771,
+            "name": "bam! interactive marketing GmbH ",
+            "purposes": [
+                1,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://bam-interactive.de/privacy-policy/"
+        },
+        "772": {
+            "id": 772,
+            "name": "Oracle Data Cloud - Moat",
+            "purposes": [],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.oracle.com/legal/privacy/services-privacy-policy.html"
+        },
+        "773": {
+            "id": 773,
+            "name": "360e-com Sp. z o.o.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.clickonometrics.com/optout/"
+        },
+        "774": {
+            "id": 774,
+            "name": "Wagawin GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.wagawin.com/privacy-en/#productprivacy"
+        },
+        "775": {
+            "id": 775,
+            "name": "SelectMedia International LTD",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.selectmedia.asia/terms-and-privacy/"
+        },
+        "776": {
+            "id": 776,
+            "name": "Mars Media Group",
+            "purposes": [
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2
+            ],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://pay-per-leads.com/terms"
+        },
+        "777": {
+            "id": 777,
+            "name": "One Planet Only",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://oneplanetonly.com/files/PRIVACY%20POLICY.pdf",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "778": {
+            "id": 778,
+            "name": "Discover-Tech ltd",
+            "purposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://discover-tech.io/dsp-privacy-policy/"
+        },
+        "779": {
+            "id": 779,
+            "name": "Adtarget Medya A.S.",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://adtarget.com.tr/adtarget-privacy-policy-2020.pdf"
+        },
+        "780": {
+            "id": 780,
+            "name": "Aniview LTD",
+            "purposes": [
+                1,
+                2,
+                7,
+                8
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.aniview.com/privacy-policy/"
+        },
+        "781": {
+            "id": 781,
+            "name": "FeedAd GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                5,
+                6,
+                8,
+                9
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://feedad.com/privacy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "782": {
+            "id": 782,
+            "name": "AirGrid LTD",
+            "purposes": [
+                1,
+                3,
+                5,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "airgid.io/privacy-policy"
+        },
+        "783": {
+            "id": 783,
+            "name": "Audienzz AG",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://audienzz.ch/wp-content/uploads/2020/03/AGB_audienzz_2020.pdf"
+        },
+        "784": {
+            "id": 784,
+            "name": "Nubo LTD",
+            "purposes": [],
+            "legIntPurposes": [
+                2
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.recod3.com/privacypolicy.php"
+        },
+        "785": {
+            "id": 785,
+            "name": "agof - daily digital facts",
+            "purposes": [
+                1,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.agof.de/datenschutz/"
+        },
+        "755": {
+            "id": 755,
+            "name": "Google Advertising Products",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                5,
+                6,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://policies.google.com/privacy"
+        },
+        "786": {
+            "id": 786,
+            "name": "TargetVideo GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                7,
+                8,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.target-video.com/datenschutz/"
+        },
+        "787": {
+            "id": 787,
+            "name": "Resolution Media M\u00fcnchen GmbH",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://wwww.nonstoppartner.net"
+        },
+        "788": {
+            "id": 788,
+            "name": "Ad Alliance GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ad-alliance.de/datenschutz/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "789": {
+            "id": 789,
+            "name": "IP Deutschland GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.ip.de/lp/impressum/datenschutz.cfm",
+            "overflow": {
+                "httpGetLimit": 32
+            }
+        },
+        "790": {
+            "id": 790,
+            "name": "AdGear Technologies, Inc.",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                9,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://adgear.com/en/privacy"
+        },
+        "791": {
+            "id": 791,
+            "name": "Media Square",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://www.mediasquare.fr/e-privacy/"
+        },
+        "792": {
+            "id": 792,
+            "name": "BritePool Inc",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                3,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                3,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                1,
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://britepool.com/gdpr-privacy-notice"
+        },
+        "794": {
+            "id": 794,
+            "name": "Kubient Inc. ",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://kubient.com/privacy-policy/"
+        },
+        "795": {
+            "id": 795,
+            "name": "Factor Eleven GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://www.factor-eleven.de/datenschutz/"
+        },
+        "796": {
+            "id": 796,
+            "name": "EASY Marketing GmbH",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://easy-m.de/"
+        },
+        "797": {
+            "id": 797,
+            "name": "Artefact Deutschland GmbH",
+            "purposes": [
+                1,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                7
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                2,
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://aaa.artefact.com/privacy-policy.do"
+        },
+        "798": {
+            "id": 798,
+            "name": "Adverticum cPlc.",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [
+                7
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://adverticum.net/english/privacy-and-data-processing-information/"
+        },
+        "799": {
+            "id": 799,
+            "name": "Adpone SL",
+            "purposes": [
+                1,
+                2,
+                4,
+                5,
+                7,
+                9
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                2
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [],
+            "policyUrl": "http://www.adpone.com/privacy-policy/"
+        },
+        "800": {
+            "id": 800,
+            "name": "Reppublika- The Research Toolbox GmbH",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                10
+            ],
+            "specialPurposes": [
+                1
+            ],
+            "features": [
+                2
+            ],
+            "specialFeatures": [
+                1
+            ],
+            "policyUrl": "https://www.reppublika.com/privacy-policy"
+        },
+        "801": {
+            "id": 801,
+            "name": "Bannernow, Inc.",
+            "purposes": [
+                1,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://bannernow.com/privacy"
+        },
+        "802": {
+            "id": 802,
+            "name": "NOW GmbH",
+            "purposes": [
+                1,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [
+                2,
+                5,
+                6,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1,
+                2,
+                3
+            ],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://static.now-services.de/privacy/index.html"
+        },
+        "803": {
+            "id": 803,
+            "name": "Click Tech Limited",
+            "purposes": [
+                1,
+                2
+            ],
+            "legIntPurposes": [
+                3
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                1
+            ],
+            "specialFeatures": [],
+            "policyUrl": "https://en.yeahmobi.com/html/privacypolicy/",
+            "overflow": {
+                "httpGetLimit": 128
+            }
+        },
+        "804": {
+            "id": 804,
+            "name": "LinkedIn Ireland Unlimited Company",
+            "purposes": [
+                1,
+                3,
+                4
+            ],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.linkedin.com/legal/privacy-policy"
+        },
+        "805": {
+            "id": 805,
+            "name": "LEESTEN INC",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [
+                1,
+                2
+            ],
+            "policyUrl": "https://www.leesten.io/privacy-policy"
+        },
+        "807": {
+            "id": 807,
+            "name": "Moloco, Inc.",
+            "purposes": [
+                1
+            ],
+            "legIntPurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                8,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [
+                3
+            ],
+            "specialFeatures": [
+                2
+            ],
+            "policyUrl": "http://www.molocoads.com/private-policy.html"
+        },
+        "808": {
+            "id": 808,
+            "name": "Pure Local Media GmbH",
+            "purposes": [],
+            "legIntPurposes": [
+                2,
+                7,
+                10
+            ],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://purelocalmedia.de/?page_id=593"
+        },
+        "809": {
+            "id": 809,
+            "name": "adnanny.com SLU",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "http://adnanny.com/en/privacy/"
+        },
+        "811": {
+            "id": 811,
+            "name": "iPROM",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://iprom.eu/privacy_policy/GDPR"
+        },
+        "793": {
+            "id": 793,
+            "name": "Amazon Advertising",
+            "purposes": [
+                1,
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "legIntPurposes": [],
+            "flexiblePurposes": [
+                2,
+                3,
+                4,
+                7,
+                9,
+                10
+            ],
+            "specialPurposes": [
+                1,
+                2
+            ],
+            "features": [],
+            "specialFeatures": [],
+            "policyUrl": "https://www.amazon.co.uk/gp/help/customer/display.html?nodeId=201909010"
+        }
+    }
+}


### PR DESCRIPTION
NPM does not intentionally allow symlinks in its build process. Issue [here](https://github.com/npm/npm/issues/3310). This causes the `vendor-list.json` inside v2 not to be added to the build. This can be reproduced by running `npm pack` inside the `testing` folder and inspecting the output of the contents. This was causing an error when `TCModelFactory.noGVL();` and `TCModelFactory.withGVL();` were called. Reported issue [here](https://github.com/InteractiveAdvertisingBureau/iabtcf-es/issues/418). 

To fix this issue, I removed the symbolic link and replaced it with a hard copy. This allows npm to include it in its builds and should fix the error mentioned above. 