### PR TITLE
Fixed issue 457

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -61,9 +61,17 @@ export class SemanticPreEncoder {
                 /**
                  * Per June 2021 Policy change, Vendors declaring only Special Purposes must
                  * have their legitimate interest Vendor bit set if they have been disclosed.
-                 * This empty block ensures their LI bit remains set
+                 * This block ensures their LI bit remains set
                  */
-
+                vector.set(vendorId);
+                } else if (gvlVendorKey === 'legIntPurposes' && vendor['purposes'].length > 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
+              ) {
+                /**
+                 * Per June 2021 Policy change, Vendors declaring only Special Purposes must
+                 * have their legitimate interest Vendor bit set if they have been disclosed.
+                 * This block ensures their LI bit remains set
+                 */
+                vector.set(vendorId);
               } else {
 
                 /**

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -212,7 +212,7 @@ describe('TCString', (): void => {
     });
 
     tcModel.vendorLegitimateInterests.forEach((value: boolean, id: number): void => {
-      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 1n 615 have special purposes only declared. LI needs to be true
+      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 and 615 have special purposes only declared. LI needs to be true
       if ( (id === 415 || id === 612 || id === 615 ) && value ) {
         expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
       } 

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -120,6 +120,17 @@ describe('TCString', (): void => {
 
   });
 
+
+  // The next tests require that we use GVL tcf ver 2 and gvl version 51. If we update the tests to a newer GVL
+  // this test and the test against specific vendors that only set special purposes or only purposes and special
+  // purposes will need to be updated.
+  it('should use vendor list tcf ver 2 and gvl version 51', (): void => {
+    const gvl = getTCModel().gvl;
+
+    expect(gvl.gvlSpecificationVersion, `gvl.gvlSpecificationVersion === 2`).to.equal(2);
+    expect(gvl.vendorListVersion, `gvl.vendorListVersion == 51`).to.equal(51);
+  });
+
   it('should add a segment to a model on decode if a model is passed in', (): void => {
 
     const tcModel = getTCModel();
@@ -160,6 +171,10 @@ describe('TCString', (): void => {
 
           expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
 
+        } else if (vendor && vendor.purposes.length > 0 && vendor.specialPurposes.length > 0) {
+
+            expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
+  
         } else {
 
           expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
@@ -194,6 +209,19 @@ describe('TCString', (): void => {
 
       }
 
+    });
+
+    tcModel.vendorLegitimateInterests.forEach((value: boolean, id: number): void => {
+      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 1n 615 have special purposes only declared. LI needs to be true
+      if ( (id === 415 || id === 612 || id === 615 ) && value ) {
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
+      } 
+
+      // use case: The number of Vendors that have declared only purposes based on consent (no LI) + at least one SP
+      // sample set in v2-51: ids: 545, 553, 565, 570
+      if ( (id === 545 || id === 553 || id === 565 || id === 570) && value ) {
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorConsentSetAndLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
+      }
     });
 
     TCString.decode(publisherTC, newModel);


### PR DESCRIPTION
Added additional test cases to test to handle the two use cases:
- vendor has no purposes consent and no LI but special purposes specified. The LI bit should be 1.
- vendor has purpose consent, no LI but special purposes specified. The LI git should be 1.

Update the code in SemanticPreEncoder to ensure in these two use cases the LI bit is actually set for the vendor.