### PR TITLE
More translations and updates to test

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -61,9 +61,17 @@ export class SemanticPreEncoder {
                 /**
                  * Per June 2021 Policy change, Vendors declaring only Special Purposes must
                  * have their legitimate interest Vendor bit set if they have been disclosed.
-                 * This empty block ensures their LI bit remains set
+                 * This block ensures their LI bit remains set
                  */
-
+                vector.set(vendorId);
+                } else if (gvlVendorKey === 'legIntPurposes' && vendor['purposes'].length > 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
+              ) {
+                /**
+                 * Per June 2021 Policy change, Vendors declaring only Special Purposes must
+                 * have their legitimate interest Vendor bit set if they have been disclosed.
+                 * This block ensures their LI bit remains set
+                 */
+                vector.set(vendorId);
               } else {
 
                 /**

--- a/modules/core/src/model/ConsentLanguages.ts
+++ b/modules/core/src/model/ConsentLanguages.ts
@@ -18,6 +18,7 @@ export class ConsentLanguages {
     'FR',
     'GL',
     'HE',
+    'HI',
     'HR',
     'HU',
     'ID',
@@ -50,6 +51,7 @@ export class ConsentLanguages {
     'UK',
     'VI',
     'ZH',
+    'ZH-HANT',
   ]);
 
   public has(key: string): boolean {

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -212,7 +212,7 @@ describe('TCString', (): void => {
     });
 
     tcModel.vendorLegitimateInterests.forEach((value: boolean, id: number): void => {
-      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 1n 615 have special purposes only declared. LI needs to be true
+      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 and 615 have special purposes only declared. LI needs to be true
       if ( (id === 415 || id === 612 || id === 615 ) && value ) {
         expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
       } 

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -120,6 +120,17 @@ describe('TCString', (): void => {
 
   });
 
+
+  // The next tests require that we use GVL tcf ver 2 and gvl version 51. If we update the tests to a newer GVL
+  // this test and the test against specific vendors that only set special purposes or only purposes and special
+  // purposes will need to be updated.
+  it('should use vendor list tcf ver 2 and gvl version 51', (): void => {
+    const gvl = getTCModel().gvl;
+
+    expect(gvl.gvlSpecificationVersion, `gvl.gvlSpecificationVersion === 2`).to.equal(2);
+    expect(gvl.vendorListVersion, `gvl.vendorListVersion == 51`).to.equal(51);
+  });
+
   it('should add a segment to a model on decode if a model is passed in', (): void => {
 
     const tcModel = getTCModel();
@@ -160,6 +171,10 @@ describe('TCString', (): void => {
 
           expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
 
+        } else if (vendor && vendor.purposes.length > 0 && vendor.specialPurposes.length > 0) {
+
+            expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
+  
         } else {
 
           expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
@@ -194,6 +209,19 @@ describe('TCString', (): void => {
 
       }
 
+    });
+
+    tcModel.vendorLegitimateInterests.forEach((value: boolean, id: number): void => {
+      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 1n 615 have special purposes only declared. LI needs to be true
+      if ( (id === 415 || id === 612 || id === 615 ) && value ) {
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
+      } 
+
+      // use case: The number of Vendors that have declared only purposes based on consent (no LI) + at least one SP
+      // sample set in v2-51: ids: 545, 553, 565, 570
+      if ( (id === 545 || id === 553 || id === 565 || id === 570) && value ) {
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorConsentSetAndLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
+      }
     });
 
     TCString.decode(publisherTC, newModel);

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -195,6 +195,16 @@ describe('TCString', (): void => {
 
     });
 
+    // use case: vendor has at least one special purpose but NO purposes declared. Using tcModel.vendorConsents.set() should not
+    // set the purpose bit (using id 278, 415, 484 (GVL v51) as an example)
+    tcModel.purposeConsents.set([278, 415, 484]);
+    const encodedString = TCString.encode(tcModel);
+    const newModel2 = TCString.decode(encodedString);
+    newModel2.purposeConsents.forEach((value: boolean, id: number): void => {
+      if (id === 278 || id === 415 || id === 484)
+      expect(newModel2.purposeConsents.has(id), `specialPurposeButNoPurposeConsent.has(${id})`).to.equal(false);
+    });
+
     tcModel.purposeLegitimateInterests.forEach((value: boolean, id: number): void => {
 
       if ( (id === 1 || id >= 3 && id <= 6) && value ) {

--- a/modules/core/test/model/ConsentLanguages.test.ts
+++ b/modules/core/test/model/ConsentLanguages.test.ts
@@ -23,6 +23,7 @@ describe('model->ConsentLanguages', (): void => {
     'FR',
     'GL',
     'HE',
+    'HI',
     'HR',
     'HU',
     'ID',
@@ -55,6 +56,7 @@ describe('model->ConsentLanguages', (): void => {
     'UK',
     'VI',
     'ZH',
+    'ZH-HANT',
   ];
 
   it('should have only these languages', (): void => {


### PR DESCRIPTION
This PR introduces support for languages Hindi and Traditional Chinese and updated the translation test.
Update the TC string test to test against the use case reported in issue 456.
