### PR TITLE
Initiual update to support TCF v2.3"

### DIFF
--- a/modules/cmpapi/src/response/TCData.ts
+++ b/modules/cmpapi/src/response/TCData.ts
@@ -36,6 +36,7 @@ export class TCData extends Response {
 
     consents: BooleanVector | string;
     legitimateInterests: BooleanVector | string;
+    disclosedVendors: BooleanVector | string;
 
   };
 
@@ -98,6 +99,7 @@ export class TCData extends Response {
 
         consents: this.createVectorField(tcModel.vendorConsents, vendorIds),
         legitimateInterests: this.createVectorField(tcModel.vendorLegitimateInterests, vendorIds),
+        disclosedVendors: this.createVectorField(tcModel.vendorsDisclosed, vendorIds),
 
       };
 

--- a/modules/cmpapi/test/TestUtils.ts
+++ b/modules/cmpapi/test/TestUtils.ts
@@ -162,6 +162,7 @@ export class TestUtils {
 
     this.checkVectorToBooleanVector('vendor.consents', tcModel.vendorConsents, tcData.vendor.consents as BooleanVector, vendors);
     this.checkVectorToBooleanVector('vendor.legitimateInterests', tcModel.vendorLegitimateInterests, tcData.vendor.legitimateInterests as BooleanVector, vendors);
+    this.checkVectorToBooleanVector('vendor.disclosedVendors', tcModel.vendorsDisclosed, tcData.vendor.disclosedVendors as BooleanVector, vendors);
 
     this.checkVectorToBooleanVector('specialFeatureOptins', tcModel.specialFeatureOptins, tcData.specialFeatureOptins as BooleanVector);
 

--- a/modules/cmpapi/test/command/GetTCDataCommand.test.ts
+++ b/modules/cmpapi/test/command/GetTCDataCommand.test.ts
@@ -11,6 +11,9 @@ describe('command->GetTCDataCommand', (): void => {
 
     CmpApiModel.gdprApplies = true;
     CmpApiModel.tcModel = TCModelFactory.withGVL();
+    CmpApiModel.tcModel.isServiceSpecific = true;
+    CmpApiModel.tcModel.supportOOB = false;
+
     CmpApiModel.tcString = TCString.encode(CmpApiModel.tcModel);
 
     const tcDataCallback = (tcData: TCData, success: boolean): void => {

--- a/modules/core/src/encoder/sequence/SegmentSequence.ts
+++ b/modules/core/src/encoder/sequence/SegmentSequence.ts
@@ -30,6 +30,7 @@ export class SegmentSequence implements SequenceVersionMap {
          */
 
         this['2'].push(Segment.PUBLISHER_TC);
+        this['2'].push(Segment.VENDORS_DISCLOSED);
 
       } else {
 

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -57,6 +57,29 @@ describe('TCString', (): void => {
 
   });
 
+  it('should set all vendorsDisclosed for TCF v2.3', (): void => {
+
+    const tcModel = getTCModel();
+
+    tcModel.vendorsDisclosed.empty();
+    tcModel.isServiceSpecific = true;
+    tcModel.supportOOB = false;
+    tcModel.publisherCountryCode = "DE";
+
+    const encodedString = TCString.encode(tcModel);
+    const newModel = TCString.decode(encodedString);
+
+    const vIds: number[] = Object.keys(tcModel.gvl.vendors).map((vId: string): number => parseInt(vId, 10));
+
+    vIds.forEach((vendorId: number): void => {
+
+      expect(newModel.vendorsDisclosed.has(vendorId), `newModel.vendorsDisclosed.has(${vendorId})`).to.be.true;
+      expect(tcModel.vendorsDisclosed.has(vendorId), `tcModel.vendorsDisclosed.has(${vendorId})`).to.be.false;
+
+    });
+
+  });
+
   it('should set all vendorsDisclosed in the GVL when isServiceSpecific is false', (): void => {
 
     const tcModel = getTCModel();

--- a/modules/core/test/encoder/sequence/SegmentSequence.test.ts
+++ b/modules/core/test/encoder/sequence/SegmentSequence.test.ts
@@ -74,9 +74,9 @@ describe('encoder/sequence->SegmentSequence', (): void => {
              * v2:  isServiceSpecific=true, isForSaving=false, hasVendorsAllowed=false, and supportOOB=false
              */
 
-            expect(sequence.length, `sequence.length`).to.equal(2);
+            expect(sequence.length, `sequence.length`).to.equal(3);
             expect(sequence[1], `sequence[1]`).to.equal(Segment.PUBLISHER_TC);
-
+            expect(sequence[2], `sequence[2]`).to.equal(Segment.VENDORS_DISCLOSED);
           } else {
 
             if (!isForSaving) {


### PR DESCRIPTION
This PR introduces the changes require to support TCF verdion 2.3 (making the disclose vendors a mandary field in the TC string). 
- add the disclosed vendors section as a mandatory section into the TC stirng
- adds the disclosed vendors to the vendor sectionas a new map 'vendorsDisclosed'
- updates the tests 