### PR TITLE
Fixed issue-481

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -159,8 +159,6 @@ export class SemanticPreEncoder {
 
       });
 
-      tcModel.vendorsDisclosed.set(gvl.vendors);
-
       return tcModel;
 
     },

--- a/modules/core/test/ReportedIssues.test.ts
+++ b/modules/core/test/ReportedIssues.test.ts
@@ -161,6 +161,28 @@ describe('Issues Reported', (): void => {
 
   });
 
+  it('481 TCString.encode writes given disclosed vendors correctly (vendor set using .set()', async (): Promise<void> => {
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const vendorlist = JSON.parse(fs.readFileSync(__dirname + '/../../testing/lib/mjs/vendorlist/v2/vendor-list.json').toString());
+
+    const tcModel = new TCModel(new GVL(vendorlist));
+    tcModel.cmpId = makeRandomInt(2, 100);
+    tcModel.cmpVersion = makeRandomInt(1, 100);
+
+    await tcModel.gvl.readyPromise;
+   
+    tcModel.vendorsDisclosed.empty();
+    tcModel.vendorsDisclosed.set([1]);
+
+    expect(tcModel.vendorsDisclosed.size, 'tcModel.vendorsDisclosed.size').to.equal(1);
+
+    const decoded = TCString.decode(TCString.encode(tcModel));
+
+    expect(decoded.vendorsDisclosed.size, 'decoded.vendorsDisclosed.size').to.equal(1);
+
+  });
+
   it('142 it should throw an error if the bitfield length does not match the maxId', (): void => {
 
     const str = 'CLSYjTaOngnCIAOABBENAXCMAGOAABBAAA7IA5n-m7fP6_3fbqVv6E__PoA5Aqff3aJx8tv_1967rfnQEQoAIAAQCrwkAEABAcACABIMACAAuApEVABABUSABgBCAVSAtIoACACIArYQAHACgAFgAVwBJgDcAI7AWgMAAgBiKgAgBMgFfKQAQBRkQAQA4AFiBAAoA-AEVAJlAVgAtYcACAJcAr4eABAK8OgBgFzAOmAqwgABAWyA.IFukWSQh';

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -57,11 +57,12 @@ describe('TCString', (): void => {
 
   });
 
-  it('should set all vendorsDisclosed for TCF v2.3', (): void => {
+  it('should unset vendorsDisclosed', (): void => {
 
     const tcModel = getTCModel();
 
     tcModel.vendorsDisclosed.empty();
+    tcModel.unsetAllVendorsDisclosed();
     tcModel.isServiceSpecific = true;
     tcModel.supportOOB = false;
     tcModel.publisherCountryCode = 'DE';
@@ -73,19 +74,20 @@ describe('TCString', (): void => {
 
     vIds.forEach((vendorId: number): void => {
 
-      expect(newModel.vendorsDisclosed.has(vendorId), `newModel.vendorsDisclosed.has(${vendorId})`).to.be.true;
+      expect(newModel.vendorsDisclosed.has(vendorId), `newModel.vendorsDisclosed.has(${vendorId})`).to.be.false;
       expect(tcModel.vendorsDisclosed.has(vendorId), `tcModel.vendorsDisclosed.has(${vendorId})`).to.be.false;
 
     });
 
   });
 
-  it('should set all vendorsDisclosed in the GVL when isServiceSpecific is false', (): void => {
+  it('should set vendorsDisclosed to all vendors in the GVL', (): void => {
 
     const tcModel = getTCModel();
 
     tcModel.vendorsDisclosed.empty();
-    tcModel.isServiceSpecific = false;
+    tcModel.setAllVendorsDisclosed();
+    tcModel.isServiceSpecific = true;
 
     const encodedString = TCString.encode(tcModel);
     const newModel = TCString.decode(encodedString);
@@ -95,7 +97,7 @@ describe('TCString', (): void => {
     vIds.forEach((vendorId: number): void => {
 
       expect(newModel.vendorsDisclosed.has(vendorId), `newModel.vendorsDisclosed.has(${vendorId})`).to.be.true;
-      expect(tcModel.vendorsDisclosed.has(vendorId), `tcModel.vendorsDisclosed.has(${vendorId})`).to.be.false;
+      expect(tcModel.vendorsDisclosed.has(vendorId), `tcModel.vendorsDisclosed.has(${vendorId})`).to.be.true;
 
     });
 


### PR DESCRIPTION
Problem reported: 
I’m trying to hardcode vendorsDisclosed as [1] in my tcModel. However, when I encode it and immediately decode the encoded string (CQXyWYAQXyWYAAcAAAENB8FAAAAAAAAAAAAAAAAAAAAA.ILmtR_G__bXlv-b736ftkeYxf9_hr7sQxBgbJs24FzLvW_JwX32E7NEzatqYKmRIAu3TBIQNtHJjURVChKIgVrzDsaEyUoTtKJ-BkiHMRY2NYCFxvm4pjeQCZ5vr_91d9mT-N7dr-2dzyy7hnv3a9_-S1WJidKYetHfv8bBKT-IU9_x-4v4_N7pE2-eS1v_tGvt639-4vv_dpvx9_76ffz____73_e7X__f_______3f__________-A.YAAAAAAAAAAA)
It looks to me as the complete list of vendorsDisclosed is always written out.

Fix:
Analyzed the issue and found that in module SemanticPreEncorder.ts a line of code that always sets the vendorsdisclosed to true for all vendors. This was debug/testing code that was not removed.