### PR TITLE
Fixed order of the segments (core, disclosed, pub restriction)

### DIFF
--- a/modules/core/src/encoder/sequence/FieldSequence.ts
+++ b/modules/core/src/encoder/sequence/FieldSequence.ts
@@ -39,6 +39,9 @@ export class FieldSequence implements SequenceVersionMap {
       Fields.vendorLegitimateInterests,
       Fields.publisherRestrictions,
     ],
+    [Segment.VENDORS_DISCLOSED]: [
+      Fields.vendorsDisclosed,
+    ],
     [Segment.PUBLISHER_TC]: [
       Fields.publisherConsents,
       Fields.publisherLegitimateInterests,
@@ -48,9 +51,6 @@ export class FieldSequence implements SequenceVersionMap {
     ],
     [Segment.VENDORS_ALLOWED]: [
       Fields.vendorsAllowed,
-    ],
-    [Segment.VENDORS_DISCLOSED]: [
-      Fields.vendorsDisclosed,
     ],
   };
 

--- a/modules/core/src/encoder/sequence/SegmentSequence.ts
+++ b/modules/core/src/encoder/sequence/SegmentSequence.ts
@@ -29,8 +29,8 @@ export class SegmentSequence implements SequenceVersionMap {
          * saving or the cmp api to surface.
          */
 
-        this['2'].push(Segment.PUBLISHER_TC);
         this['2'].push(Segment.VENDORS_DISCLOSED);
+        this['2'].push(Segment.PUBLISHER_TC);
 
       } else {
 

--- a/modules/core/test/encoder/sequence/FieldSequence.test.ts
+++ b/modules/core/test/encoder/sequence/FieldSequence.test.ts
@@ -34,9 +34,9 @@ describe('encoder/sequence->FieldSequence', (): void => {
 
     expect(seq['2'], 'keys seq["2"]').to.have.all.keys([
       Segment.CORE,
+      Segment.VENDORS_DISCLOSED,
       Segment.PUBLISHER_TC,
       Segment.VENDORS_ALLOWED,
-      Segment.VENDORS_DISCLOSED,
     ]);
 
     const coreSequence = seq['2'][Segment.CORE];

--- a/modules/core/test/encoder/sequence/SegmentSequence.test.ts
+++ b/modules/core/test/encoder/sequence/SegmentSequence.test.ts
@@ -75,8 +75,8 @@ describe('encoder/sequence->SegmentSequence', (): void => {
              */
 
             expect(sequence.length, `sequence.length`).to.equal(3);
-            expect(sequence[1], `sequence[1]`).to.equal(Segment.PUBLISHER_TC);
-            expect(sequence[2], `sequence[2]`).to.equal(Segment.VENDORS_DISCLOSED);
+            expect(sequence[1], `sequence[1]`).to.equal(Segment.VENDORS_DISCLOSED);
+            expect(sequence[2], `sequence[2]`).to.equal(Segment.PUBLISHER_TC);
 
           } else {
 


### PR DESCRIPTION
This address issue 487. Fixed the order of the segments to follow the spec.