### PR TITLE
Removed workaround for SP only vendors, fixed tests and lint errors.

### DIFF
--- a/modules/core/src/encoder/SemanticPreEncoder.ts
+++ b/modules/core/src/encoder/SemanticPreEncoder.ts
@@ -54,100 +54,74 @@ export class SemanticPreEncoder {
 
             } else if (vendor[gvlVendorKey].length === 0) {
 
-              if (
-                gvlVendorKey === 'legIntPurposes' && vendor['purposes'].length === 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
-              ) {
+              /**
+               * If the vendor does exist, but they haven't declared any
+               * purposes for this legal basis, then we need to see if they can
+               * possibly have the legal basis from their flexible purposes.
+               */
 
-                /**
-                 * Per June 2021 Policy change, Vendors declaring only Special Purposes must
-                 * have their legitimate interest Vendor bit set if they have been disclosed.
-                 * This block ensures their LI bit remains set
-                 */
-                vector.set(vendorId);
+              if (tcModel.isServiceSpecific) {
 
-              } else if (
-                gvlVendorKey === 'legIntPurposes' && vendor['purposes'].length > 0 && vendor['legIntPurposes'].length === 0 && vendor['specialPurposes'].length > 0
-              ) {
+                if (vendor.flexiblePurposes.length === 0) {
 
-                /**
-                 * Per June 2021 Policy change, Vendors declaring only Special Purposes must
-                 * have their legitimate interest Vendor bit set if they have been disclosed.
-                 * This block ensures their LI bit remains set
-                 */
-                vector.set(vendorId);
-
-              } else {
-
-                /**
-                 * If the vendor does exist, but they haven't declared any
-                 * purposes for this legal basis, then we need to see if they can
-                 * possibly have the legal basis from their flexible purposes.
-                 */
-
-                if (tcModel.isServiceSpecific) {
-
-                  if (vendor.flexiblePurposes.length === 0) {
-
-                    /**
-                     * No flexible basis for any purposes, so we can safely remove
-                     * this vendor from the legal basis.
-                     */
-                    vector.unset(vendorId);
-
-                  } else {
-
-                    /**
-                     * They have some flexible purposes, we should check for a
-                     * publisher restriction value that would enable this vendor to
-                     * have the override-preferred basis.
-                     */
-                    const restrictions = tcModel.publisherRestrictions.getRestrictions(vendorId);
-                    let isValid = false;
-
-                    for (let i = 0, len = restrictions.length; i < len && !isValid; i ++) {
-
-                      /**
-                       * If this condition is true the loop will break.  If we are
-                       * dealing with the consent purposes ('purposes') and the
-                       * publisher restriction overrides to consent then it is
-                       * valid for the vendor to have a positive signal for
-                       * consent.  Likewise for legitimate interest purposes
-                       * ('legIntPurposes') and requiring legitimate interest.
-                       */
-                      isValid = (
-                        (restrictions[i].restrictionType === RestrictionType.REQUIRE_CONSENT &&
-                        gvlVendorKey === 'purposes') ||
-                      (restrictions[i].restrictionType === RestrictionType.REQUIRE_LI &&
-                        gvlVendorKey === 'legIntPurposes'));
-
-                    }
-
-                    if (!isValid) {
-
-                      /**
-                       * if we came through the previous  loop without finding a
-                       * valid reasing: no overriding restrictions (changes in
-                       * legal basis) then it's not valid for this vendor to have
-                       * this legal basis.
-                       */
-
-                      vector.unset(vendorId);
-
-                    }
-
-                  }
+                  /**
+                   * No flexible basis for any purposes, so we can safely remove
+                   * this vendor from the legal basis.
+                   */
+                  vector.unset(vendorId);
 
                 } else {
 
                   /**
-                   * This is a globally-scoped string so flexible purposes will not
-                   * be able to change this value because purposeRestrictions only
-                   * apply to service-specific strings.
+                   * They have some flexible purposes, we should check for a
+                   * publisher restriction value that would enable this vendor to
+                   * have the override-preferred basis.
                    */
+                  const restrictions = tcModel.publisherRestrictions.getRestrictions(vendorId);
+                  let isValid = false;
 
-                  vector.unset(vendorId);
+                  for (let i = 0, len = restrictions.length; i < len && !isValid; i ++) {
+
+                    /**
+                     * If this condition is true the loop will break.  If we are
+                     * dealing with the consent purposes ('purposes') and the
+                     * publisher restriction overrides to consent then it is
+                     * valid for the vendor to have a positive signal for
+                     * consent.  Likewise for legitimate interest purposes
+                     * ('legIntPurposes') and requiring legitimate interest.
+                     */
+                    isValid = (
+                      (restrictions[i].restrictionType === RestrictionType.REQUIRE_CONSENT &&
+                      gvlVendorKey === 'purposes') ||
+                    (restrictions[i].restrictionType === RestrictionType.REQUIRE_LI &&
+                      gvlVendorKey === 'legIntPurposes'));
+
+                  }
+
+                  if (!isValid) {
+
+                    /**
+                     * if we came through the previous loop without finding a
+                     * valid reasing: no overriding restrictions (changes in
+                     * legal basis) then it's not valid for this vendor to have
+                     * this legal basis.
+                     */
+
+                    vector.unset(vendorId);
+
+                  }
 
                 }
+
+              } else {
+
+                /**
+                 * This is a globally-scoped string so flexible purposes will not
+                 * be able to change this value because purposeRestrictions only
+                 * apply to service-specific strings.
+                 */
+
+                vector.unset(vendorId);
 
               }
 

--- a/modules/core/test/ReportedIssues.test.ts
+++ b/modules/core/test/ReportedIssues.test.ts
@@ -351,7 +351,7 @@ describe('Issues Reported', (): void => {
     expect(tcModel.publisherRestrictions.getVendors(new PurposeRestriction(1, 1)), `tcModel.publisherRestrictions vendor array`).to.deep.equal([7, 20, 71, 122, 140, 183]);
 
   });
-/*
+  /*
    it('xxx TCString.decode finds all vendors as disclosed', async (): Promise<void> => {
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -375,4 +375,5 @@ describe('Issues Reported', (): void => {
 
   });
   */
+
 });

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -193,19 +193,7 @@ describe('TCString', (): void => {
 
       if (!vendor || (value && vendor.legIntPurposes.length === 0)) {
 
-        if (vendor && vendor.purposes.length === 0 && vendor.specialPurposes.length > 0) {
-
-          expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
-
-        } else if (vendor && vendor.purposes.length > 0 && vendor.specialPurposes.length > 0) {
-
-          expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.true;
-
-        } else {
-
-          expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
-
-        }
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterests.has(${id})`).to.be.false;
 
       } else {
 
@@ -255,19 +243,11 @@ describe('TCString', (): void => {
 
     tcModel.vendorLegitimateInterests.forEach((value: boolean, id: number): void => {
 
-      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 and 615 have special purposes only declared. LI needs to be true
+      // gvl spec ver 2, gvl ver 51: vendor ids 415, 612 and 615 have special purposes only declared. LI should remain false
 
       if ( (id === 415 || id === 612 || id === 615 ) && value ) {
 
-        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
-
-      }
-      // use case: The number of Vendors that have declared only purposes based on consent (no LI) + at least one SP
-      // sample set in v2-51: ids: 545, 553, 565, 570
-
-      if ( (id === 545 || id === 553 || id === 565 || id === 570) && value ) {
-
-        expect(newModel.vendorLegitimateInterests.has(id), `vendorConsentSetAndLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.true;
+        expect(newModel.vendorLegitimateInterests.has(id), `vendorLegitimateInterestsForSpecialPurpose.has(${id})`).to.be.false;
 
       }
 


### PR DESCRIPTION
This update removes workaround for vendors declaring special purposes only.
It updates the tests accrodingly and fixes lint errors found. 

The changes built successfully, pass lint test and unit test.
 