### PR TITLE
Fix circular dependencies in core and cmpapi

### DIFF
--- a/modules/cmpapi/src/EventListenerQueue.ts
+++ b/modules/cmpapi/src/EventListenerQueue.ts
@@ -1,5 +1,5 @@
-import {GetTCDataCommand} from './command/GetTCDataCommand.js';
-import {CommandCallback} from './command/CommandCallback.js';
+import type {GetTCDataCommand} from './command/GetTCDataCommand.js';
+import type {CommandCallback} from './command/CommandCallback.js';
 
 interface EventItem {
   callback: CommandCallback;
@@ -7,6 +7,22 @@ interface EventItem {
   param?: any;
   next?: CommandCallback;
 }
+
+/**
+ * Holds the GetTCDataCommand constructor, registered by the GetTCDataCommand
+ * module itself when it loads (see the bottom of GetTCDataCommand.ts). This
+ * indirection lets EventListenerQueue avoid a value import of GetTCDataCommand,
+ * which would otherwise create a circular dependency that is evaluated when
+ * CmpApiModel is first loaded:
+ * CmpApiModel -> EventListenerQueue -> GetTCDataCommand -> TCData -> Response -> CmpApiModel
+ */
+let GetTCDataCommandCtor: typeof GetTCDataCommand;
+
+export const registerGetTCDataCommand = (ctor: typeof GetTCDataCommand): void => {
+
+  GetTCDataCommandCtor = ctor;
+
+};
 
 export class EventListenerQueue {
 
@@ -30,7 +46,7 @@ export class EventListenerQueue {
 
     this.eventQueue.forEach((eventItem: EventItem, listenerId: number): void => {
 
-      new GetTCDataCommand(eventItem.callback, eventItem.param, listenerId, eventItem.next);
+      new GetTCDataCommandCtor(eventItem.callback, eventItem.param, listenerId, eventItem.next);
 
     });
 

--- a/modules/cmpapi/src/command/GetTCDataCommand.ts
+++ b/modules/cmpapi/src/command/GetTCDataCommand.ts
@@ -1,5 +1,6 @@
 import {Command} from './Command.js';
 import {TCData} from '../response/index.js';
+import {registerGetTCDataCommand} from '../EventListenerQueue.js';
 
 export class GetTCDataCommand extends Command {
 
@@ -29,3 +30,11 @@ export class GetTCDataCommand extends Command {
   }
 
 }
+
+/*
+ * Register with EventListenerQueue so it can build GetTCDataCommands during
+ * exec() without importing this module at evaluation time. See the comment on
+ * registerGetTCDataCommand in EventListenerQueue.ts for why this breaks the
+ * circular dependency.
+ */
+registerGetTCDataCommand(GetTCDataCommand);

--- a/modules/cmpapi/test/CircularDependencies.test.ts
+++ b/modules/cmpapi/test/CircularDependencies.test.ts
@@ -1,0 +1,139 @@
+import {expect} from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Guards against re-introducing circular dependencies (see issue #390). A cyclic
+ * `require()` graph in the published CommonJS build triggers bundlers such as
+ * Metro (react-native) to warn about "uninitialized values" and is a frequent
+ * source of subtle load-order bugs.
+ *
+ * This walks the compiled `lib/cjs` output – where `tsc` hoists every static
+ * import to a top-level `require()` – and fails if any module can reach itself.
+ */
+describe('Circular dependencies', (): void => {
+
+  const cjsRoot = path.resolve(process.cwd(), 'lib/cjs');
+
+  const walk = (dir: string, acc: string[] = []): string[] => {
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+
+        walk(full, acc);
+
+      } else if (entry.name.endsWith('.js')) {
+
+        acc.push(full);
+
+      }
+
+    }
+
+    return acc;
+
+  };
+
+  const findCircular = (root: string): string[][] => {
+
+    const files = walk(root);
+    const fileSet = new Set<string>(files.map((f: string): string => fs.realpathSync(f)));
+    const graph = new Map<string, Set<string>>();
+
+    for (const file of files) {
+
+      const deps = new Set<string>();
+
+      for (const match of fs.readFileSync(file, 'utf8').matchAll(/require\((["'])(\.[^"']+)\1\)/g)) {
+
+        let target = path.resolve(path.dirname(file), match[2]);
+
+        if (!target.endsWith('.js')) {
+
+          target += '.js';
+
+        }
+
+        try {
+
+          const resolved = fs.realpathSync(target);
+
+          if (fileSet.has(resolved)) {
+
+            deps.add(resolved);
+
+          }
+
+        } catch {
+
+          // require target outside this package (e.g. a dependency) – ignore
+        }
+
+      }
+
+      graph.set(fs.realpathSync(file), deps);
+
+    }
+
+    const WHITE = 0;
+    const GRAY = 1;
+    const BLACK = 2;
+    const color = new Map<string, number>();
+    const stack: string[] = [];
+    const cycles: string[][] = [];
+
+    const visit = (node: string): void => {
+
+      color.set(node, GRAY);
+      stack.push(node);
+
+      for (const dep of graph.get(node) || []) {
+
+        const state = color.get(dep) || WHITE;
+
+        if (state === GRAY) {
+
+          const start = stack.indexOf(dep);
+          cycles.push(stack.slice(start).concat(dep).map((p: string): string => path.relative(root, p)));
+
+        } else if (state === WHITE) {
+
+          visit(dep);
+
+        }
+
+      }
+
+      stack.pop();
+      color.set(node, BLACK);
+
+    };
+
+    for (const node of graph.keys()) {
+
+      if ((color.get(node) || WHITE) === WHITE) {
+
+        visit(node);
+
+      }
+
+    }
+
+    return cycles;
+
+  };
+
+  it('has no circular dependencies in the compiled CommonJS output', (): void => {
+
+    expect(fs.existsSync(cjsRoot), `${cjsRoot} not found – run the build before the tests`).to.be.true;
+
+    const cycles = findCircular(cjsRoot);
+
+    expect(cycles, `circular dependencies found:\n${cycles.map((c: string[]): string => c.join(' -> ')).join('\n')}`).to.deep.equal([]);
+
+  });
+
+});

--- a/modules/cmpapi/test/EventListenerQueue.test.ts
+++ b/modules/cmpapi/test/EventListenerQueue.test.ts
@@ -4,6 +4,8 @@ import {TCStringFactory} from '@iabtechlabtcf/testing';
 import {TCString} from '@iabtechlabtcf/core';
 import {TCData} from '../src/response/TCData';
 import {CmpApiModel} from '../src/CmpApiModel';
+// Loaded for its side effect: registers GetTCDataCommand with EventListenerQueue.
+import '../src/command/GetTCDataCommand';
 
 describe('EventListenerQueue', (): void => {
 

--- a/modules/core/src/encoder/SegmentEncoder.ts
+++ b/modules/core/src/encoder/SegmentEncoder.ts
@@ -5,7 +5,7 @@ import {FieldSequence} from './sequence/index.js';
 import {EncodingError, DecodingError} from '../errors/index.js';
 import {Fields} from '../model/Fields.js';
 import {Segment, SegmentIDs} from '../model/index.js';
-import {TCModel, TCModelPropType} from '../index.js';
+import type {TCModel, TCModelPropType} from '../TCModel.js';
 
 export class SegmentEncoder {
 

--- a/modules/core/src/encoder/field/VendorVectorEncoder.ts
+++ b/modules/core/src/encoder/field/VendorVectorEncoder.ts
@@ -1,5 +1,5 @@
 import {Vector} from '../../model/index.js';
-import {BitLength} from '../index.js';
+import {BitLength} from '../BitLength.js';
 import {IntEncoder} from './IntEncoder.js';
 import {BooleanEncoder} from './BooleanEncoder.js';
 import {FixedVectorEncoder} from './FixedVectorEncoder.js';

--- a/modules/core/src/encoder/sequence/SegmentSequence.ts
+++ b/modules/core/src/encoder/sequence/SegmentSequence.ts
@@ -1,5 +1,5 @@
 import {SequenceVersionMap} from './SequenceVersionMap.js';
-import {TCModel} from '../../index.js';
+import type {TCModel} from '../../TCModel.js';
 import {EncodingOptions} from '../EncodingOptions.js';
 import {
   Segment,

--- a/modules/core/src/model/PurposeRestrictionVector.ts
+++ b/modules/core/src/model/PurposeRestrictionVector.ts
@@ -1,6 +1,6 @@
 import {PurposeRestriction} from './PurposeRestriction.js';
 import {RestrictionType} from './RestrictionType.js';
-import {GVL} from '../GVL.js';
+import type {GVL} from '../GVL.js';
 import {Vendor} from './gvl/index.js';
 import {Cloneable} from '../Cloneable.js';
 

--- a/modules/core/test/CircularDependencies.test.ts
+++ b/modules/core/test/CircularDependencies.test.ts
@@ -1,0 +1,139 @@
+import {expect} from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Guards against re-introducing circular dependencies (see issue #390). A cyclic
+ * `require()` graph in the published CommonJS build triggers bundlers such as
+ * Metro (react-native) to warn about "uninitialized values" and is a frequent
+ * source of subtle load-order bugs.
+ *
+ * This walks the compiled `lib/cjs` output – where `tsc` hoists every static
+ * import to a top-level `require()` – and fails if any module can reach itself.
+ */
+describe('Circular dependencies', (): void => {
+
+  const cjsRoot = path.resolve(process.cwd(), 'lib/cjs');
+
+  const walk = (dir: string, acc: string[] = []): string[] => {
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+
+        walk(full, acc);
+
+      } else if (entry.name.endsWith('.js')) {
+
+        acc.push(full);
+
+      }
+
+    }
+
+    return acc;
+
+  };
+
+  const findCircular = (root: string): string[][] => {
+
+    const files = walk(root);
+    const fileSet = new Set<string>(files.map((f: string): string => fs.realpathSync(f)));
+    const graph = new Map<string, Set<string>>();
+
+    for (const file of files) {
+
+      const deps = new Set<string>();
+
+      for (const match of fs.readFileSync(file, 'utf8').matchAll(/require\((["'])(\.[^"']+)\1\)/g)) {
+
+        let target = path.resolve(path.dirname(file), match[2]);
+
+        if (!target.endsWith('.js')) {
+
+          target += '.js';
+
+        }
+
+        try {
+
+          const resolved = fs.realpathSync(target);
+
+          if (fileSet.has(resolved)) {
+
+            deps.add(resolved);
+
+          }
+
+        } catch {
+
+          // require target outside this package (e.g. a dependency) – ignore
+        }
+
+      }
+
+      graph.set(fs.realpathSync(file), deps);
+
+    }
+
+    const WHITE = 0;
+    const GRAY = 1;
+    const BLACK = 2;
+    const color = new Map<string, number>();
+    const stack: string[] = [];
+    const cycles: string[][] = [];
+
+    const visit = (node: string): void => {
+
+      color.set(node, GRAY);
+      stack.push(node);
+
+      for (const dep of graph.get(node) || []) {
+
+        const state = color.get(dep) || WHITE;
+
+        if (state === GRAY) {
+
+          const start = stack.indexOf(dep);
+          cycles.push(stack.slice(start).concat(dep).map((p: string): string => path.relative(root, p)));
+
+        } else if (state === WHITE) {
+
+          visit(dep);
+
+        }
+
+      }
+
+      stack.pop();
+      color.set(node, BLACK);
+
+    };
+
+    for (const node of graph.keys()) {
+
+      if ((color.get(node) || WHITE) === WHITE) {
+
+        visit(node);
+
+      }
+
+    }
+
+    return cycles;
+
+  };
+
+  it('has no circular dependencies in the compiled CommonJS output', (): void => {
+
+    expect(fs.existsSync(cjsRoot), `${cjsRoot} not found – run the build before the tests`).to.be.true;
+
+    const cycles = findCircular(cjsRoot);
+
+    expect(cycles, `circular dependencies found:\n${cycles.map((c: string[]): string => c.join(' -> ')).join('\n')}`).to.deep.equal([]);
+
+  });
+
+});


### PR DESCRIPTION
Resolves the runtime `require` cycles that bundlers such as Metro flag as *"Require cycle ... can result in uninitialized values"*.

- **core** (fixes #390): use `import type` for type-only imports and import values from their source module instead of a barrel.
- **cmpapi** (fixes #348): `EventListenerQueue` no longer imports `GetTCDataCommand` at module-evaluation time; `GetTCDataCommand` registers itself on load.

Both changes are internal only and preserve the public API. Adds a regression test in core and cmpapi that fails on any circular dependency in the compiled CommonJS output.